### PR TITLE
chore(config): add config files and basic settings

### DIFF
--- a/Back/.gitattributes
+++ b/Back/.gitattributes
@@ -1,0 +1,3 @@
+/gradlew text eol=lf
+*.bat text eol=crlf
+*.jar binary

--- a/Back/.gitignore
+++ b/Back/.gitignore
@@ -1,0 +1,37 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/

--- a/Back/src/main/java/com/mjsec/ctf/CtfApplication.java
+++ b/Back/src/main/java/com/mjsec/ctf/CtfApplication.java
@@ -2,7 +2,9 @@ package com.mjsec.ctf;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CtfApplication {
 

--- a/Back/src/main/java/com/mjsec/ctf/config/PasswordEncoderConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.mjsec.ctf.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
@@ -1,0 +1,72 @@
+package com.mjsec.ctf.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Collections;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtService jwtService;
+
+    public SecurityConfig(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOrigins(
+                                Arrays.asList("http://localhost:3000")); // 배포시에는 변경될 주소
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Collections.singletonList("*"));
+                        configuration.setMaxAge(3600L); // 브라우저가 CORS 관련 정보를 캐시할 시간을 설정
+                        configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization", "access"));
+
+                        return configuration;
+                    }
+                }));
+        // csrf disable (RESTful API는 일반적으로 상태가 없고, 세션을 사용하지 않기 때문에 CSRF 공격에 덜 취약하기 때문)
+        http
+                .csrf((auth) -> auth.disable());
+        // Form 로그인 방식 disable (폼 로그인은 세션을 사용하여 인증 상태를 유지하지만, JWT는 클라이언트 측에서 토큰을 저장하고 요청 시마다 토큰을 전송하여 인증을 처리하기 때문)
+        http
+                .formLogin((auth) -> auth.disable());
+        // HTTP Basic 인증 방식 disable (HTTP Basic 인증은 사용자 이름과 비밀번호를 Base64로 인코딩하여 전송하는 방식으로, 보안이 취약할 수 있음)
+        http
+                .httpBasic((auth) -> auth.disable());
+        //JWTFilter
+        http
+                .addFilterAfter(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class);
+        // 경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/swagger-ui/*", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/").permitAll()
+                );
+        //세션 설정 : STATELESS (JWT 기반 인증을 사용하는 경우, 서버는 클라이언트의 상태를 유지할 필요가 없음)
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.mjsec.ctf.config;
 
+import com.mjsec.ctf.security.JwtFilter;
+import com.mjsec.ctf.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.Collections;

--- a/Back/src/main/java/com/mjsec/ctf/config/SwaggerConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/SwaggerConfig.java
@@ -1,0 +1,18 @@
+package com.mjsec.ctf.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI api() {
+        return new OpenAPI().info(new Info()
+                .title("게시판 API")
+                .description("스프링부트 기반 게시판 API")
+        );
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/domain/BaseEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.mjsec.ctf.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@MappedSuperclass
+@SuperBuilder(builderMethodName = "doesNotUseThisBuilder")
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/Back/src/main/java/com/mjsec/ctf/dto/ErrorResponse.java
+++ b/Back/src/main/java/com/mjsec/ctf/dto/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.mjsec.ctf.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.Builder;
+import org.springframework.validation.FieldError;
+
+@Builder
+public record ErrorResponse(
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY) List<ValidationError> errors
+) {
+
+    @Builder
+    public record ValidationError(
+            String field,
+            String message
+    ) {
+        public static ValidationError of(final FieldError fieldError){
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/dto/SuccessResponse.java
+++ b/Back/src/main/java/com/mjsec/ctf/dto/SuccessResponse.java
@@ -1,0 +1,36 @@
+package com.mjsec.ctf.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.mjsec.ctf.type.ResponseMessage;
+import lombok.Builder;
+
+@Builder
+public record SuccessResponse<T>(
+        String code,
+        String message,
+        @JsonInclude(Include.NON_NULL) T data
+) {
+    public static <T> SuccessResponse<T> of(ResponseMessage message, T data) {
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message(message.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(ResponseMessage message) {
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message(message.getMessage())
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(T data) {
+        return SuccessResponse.<T>builder()
+                .code("SUCCESS")
+                .message("")
+                .data(data)
+                .build();
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/exception/GlobalExceptionHandler.java
+++ b/Back/src/main/java/com/mjsec/ctf/exception/GlobalExceptionHandler.java
@@ -1,0 +1,117 @@
+package com.mjsec.ctf.exception;
+
+import static com.mjsec.ctf.type.ErrorCode.BAD_REQUEST;
+import static com.mjsec.ctf.type.ErrorCode.INTERNAL_SERVER_ERROR;
+
+import com.mjsec.ctf.dto.ErrorResponse;
+import com.mjsec.ctf.dto.ErrorResponse.ValidationError;
+import com.mjsec.ctf.type.ErrorCode;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * RestApiException(커스텀 에러) 처리
+     *
+     * @param e RestApiException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<Object> handleCustomException(RestApiException e){
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("RestApiException occurred : ErrorCode = {} message = {}",
+                errorCode.name(), errorCode.getDescription());
+        return handleExceptionInternal(errorCode);
+    }
+
+    /**
+     * MethodArgumentNotValidException 처리 (Validation 실패 등)
+     *
+     * @param e MethodArgumentNotValidException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException occurred ", e);
+        return handleExceptionInternal(e, BAD_REQUEST);
+    }
+
+    /**
+     * IllegalArgumentException 처리 (적절하지 않은 파라미터)
+     *
+     * @param e IllegalArgumentException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
+        log.error("IllegalArgumentException occurred", e);
+        return handleExceptionInternal(BAD_REQUEST);
+    }
+
+    /**
+     * DataIntegrityViolationException 처리 (DB 제약 조건 위반)
+     *
+     * @param e DataIntegrityViolationException
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        log.error("DataIntegrityViolationException occurred", e);
+        return handleExceptionInternal(BAD_REQUEST);
+    }
+
+    /**
+     * Exception 처리
+     *
+     * @param e Exception
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleException(Exception e) {
+        log.error("Unexpected Exception occurred", e);
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(INTERNAL_SERVER_ERROR.getDescription());
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponseBody(errorCode));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponseBody((MethodArgumentNotValidException) e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponseBody(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .build();
+    }
+
+    private ErrorResponse makeErrorResponseBody(BindException e, ErrorCode errorCode) {
+        List<ValidationError> validationErrorList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .message(errorCode.getDescription())
+                .errors(validationErrorList)
+                .build();
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/exception/RestApiException.java
+++ b/Back/src/main/java/com/mjsec/ctf/exception/RestApiException.java
@@ -1,0 +1,12 @@
+package com.mjsec.ctf.exception;
+
+import com.mjsec.ctf.type.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RestApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}

--- a/Back/src/main/java/com/mjsec/ctf/security/JwtFilter.java
+++ b/Back/src/main/java/com/mjsec/ctf/security/JwtFilter.java
@@ -73,7 +73,7 @@ public class JwtFilter extends OncePerRequestFilter {
         // Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
 
         // SecurityContextHolder.getContext().setAuthentication(authToken);
-        log.info("User authenticated and set in SecurityContext: {}", email);
+        // log.info("User authenticated and set in SecurityContext: {}", email);
 
         filterChain.doFilter(request, response);
         log.info("Completed JWTFilter for request: {}", request.getRequestURI());

--- a/Back/src/main/java/com/mjsec/ctf/service/JwtService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/JwtService.java
@@ -1,0 +1,75 @@
+package com.mjsec.ctf.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtService {
+
+    private SecretKey secretKey;
+
+    @Autowired
+    public JwtService(@Value("${spring.jwt.secret}") String secret){
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getEmail(String token){
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
+    }
+
+    public List<String> getRoles(String token) {
+
+        List<?> roles = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("roles", List.class);
+
+        if (roles != null) {
+            return roles.stream()
+                    .map(Object::toString)
+                    .collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String getTokenType(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("tokenType", String.class);
+    }
+
+    /**
+     * JWT 생성
+     *
+     * @param tokenType : 토큰 타입(ACCESS 토큰 / REFRESH 토큰)
+     * @param loginId : 유저의 로그인 id
+     * @param roles : 유저의 권한
+     * @param expiredMs : 만료 시점
+     * @return JWT
+     */
+    public String createJwt(String tokenType, String loginId, List<String> roles, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("tokenType", tokenType)
+                .claim("loginId", loginId)
+                .claim("roles", roles)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/type/ErrorCode.java
+++ b/Back/src/main/java/com/mjsec/ctf/type/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.mjsec.ctf.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서부 오류가 발생했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String description;
+}

--- a/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
+++ b/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
@@ -1,0 +1,14 @@
+package com.mjsec.ctf.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+    SIGNUP_SUCCESS("회원가입 성공"),
+    LOGIN_SUCCESS("로그인 성공"),
+    ;
+
+    private final String message;
+}

--- a/Back/src/main/java/com/mjsec/ctf/type/UserRole.java
+++ b/Back/src/main/java/com/mjsec/ctf/type/UserRole.java
@@ -1,0 +1,6 @@
+package com.mjsec.ctf.type;
+
+public enum UserRole {
+    ROLE_USER,
+    ROLE_ADMIN
+}

--- a/Back/src/main/resources/application-local.yml
+++ b/Back/src/main/resources/application-local.yml
@@ -2,6 +2,8 @@ spring:
   config:
     activate:
       on-profile: local
+  jwt:
+    secret: ${JWT_SECRET}
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=UTC&CharacterEncoding=UTF-8


### PR DESCRIPTION
## 변경 사항

- 대부분의 스프링부트 프로젝트에 적용할 수 있는 기본 설정 파일, Basic 클래스, Basic enum 파일들을 추가
<img width="369" alt="스크린샷 2025-01-27 오후 11 16 08" src="https://github.com/user-attachments/assets/a0b5de82-cafc-4bc4-98ad-785f8a0bcdb8" />

## 상세 설명 

Config 패키지
- PasswordEncoderConfig : Spring Security에서 비밀번호 암호화를 위해 PasswordEncoder를 설정(BCryptPasswordEncoder를 return)
- SecurityConfig : 기본적인 Spring Security 설정을 포함, 인증 및 권한 관리 로직등을 정의(Spring Security 필터체인 커스터마이징)
- SwaggerConfig : API 문서화를 위해 Swagger를 설정(프로젝트의 REST API를 시각화된 UI로 확인할 수 있게 해줌)

Domain 패키지
- BaseEntity : 공통 엔티티 클래스(최상위 엔티티 클래스이며 주로 모든 엔티티에서 공통으로 사용하는 필드(예: createdAt, updatedAt)를 정의)

Dto(Data Transfer Object) 패키지
- ErrorResponse : 예외 발생 시 반환할 표준화된 에러 응답 형식을 정의
- SuccessResponse : 요청이 성공했을 때 반환할 표준화된 응답 형식을 정의

Exception 패키지
- GlobalExceptionHandler : 애플리케이션 전역에서 발생하는 예외를 처리, 예외에 따라 적절한 응답을 반환
- RestApiException : REST API에서 발생하는 예외를 세부적으로 정의

Security 패키지
- JwtFilter : JWT 토큰을 검증하고, 인증 정보가 포함된 요청을 처리하는 필터를 구현
<img width="1118" alt="스크린샷 2025-01-27 오후 11 25 22" src="https://github.com/user-attachments/assets/f08a4cef-3651-4258-a56a-d3e4e939c427" />
현재 주석처리된 부분이 있는데 유저의 email을 받아오는 것은 하나의 예시일뿐 loginId를 받아와도 무관(User 엔티티 클래스, UserDto 클래스, CustomUserDetails 클래스 모두 구현이 되지 않은 상태이기 때문에 유저 쪽 도메인을 맡는 팀원이 구현하셔야 합니다!!)

Service 패키지
- JwtService : JWT 토큰을 생성 및 검증하는 서비스 클래스(인증 및 권한 부여 로직을 포함)

type 패키지
- ErrorCode : 표준화된 에러 코드를 정의하는 열거형(enum)
- ResponseMessage : 응답 메시지를 관리하는 열거형(enum)
- UserRole : 사용자 권한(예: ADMIN, USER 등)을 정의하는 열거형(enum)

CtfApplication : Spring Boot 애플리케이션의 진입점으로, 프로젝트가 실행될 때 초기 설정을 담당(@EnableJpaAuditing 어노테이션이 추가됨. 엔티티 클래스의 createdAt, updatedAt를 자동으로 업데이트 해주기 위함)