### PR TITLE
feat:관리자계정 추가 및 회원정보 update API 추가

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/config/AdminUserInitializer.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/AdminUserInitializer.java
@@ -1,0 +1,37 @@
+package com.mjsec.ctf.config;
+
+import com.mjsec.ctf.domain.UserEntity;
+import com.mjsec.ctf.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AdminUserInitializer {
+
+    @Value("${SPRING_SECURITY_USER_NAME}")
+    private String adminUsername;
+
+    @Value("${SPRING_SECURITY_USER_PASSWORD}")
+    private String adminPassword;
+
+    @Bean
+    public CommandLineRunner createAdminUser(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        return args -> {
+            if (!userRepository.existsByLoginId(adminUsername)) {
+                UserEntity admin = UserEntity.builder()
+                        .loginId(adminUsername)
+                        .password(passwordEncoder.encode(adminPassword))
+                        .email("admin@example.com") 
+                        .univ("Admin Univ")       
+                        .roles("admin")
+                        .totalPoint(0)
+                        .build();
+                userRepository.save(admin);
+                System.out.println("관리자 계정 생성 완료: " + adminUsername);
+            }
+        };
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
@@ -93,6 +93,7 @@
                             .requestMatchers("/api/users/check-id").permitAll()
                             .requestMatchers("/api/users/check-email").permitAll()
                             //.requestMatchers("/api/users/logout").authenticated() // 로그아웃은 인증된 사용자만 가능
+                            .requestMatchers("/api/admin/**").hasRole("ADMIN")  //어드민 접근근
                             .requestMatchers("/api/users/profile").authenticated()
                             .requestMatchers("/api/users/profile").hasAnyRole("admin","user")
                             .requestMatchers("/reissue").permitAll() //토큰 재생성

--- a/Back/src/main/java/com/mjsec/ctf/controller/AdminController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/AdminController.java
@@ -1,0 +1,35 @@
+package com.mjsec.ctf.controller;
+
+import com.mjsec.ctf.domain.UserEntity;
+import com.mjsec.ctf.dto.SuccessResponse;
+import com.mjsec.ctf.dto.USER.UserDTO;
+import com.mjsec.ctf.service.UserService;
+import com.mjsec.ctf.type.ResponseMessage;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final UserService userService;
+
+    @Operation(summary = "회원정보 수정", description = "관리자 권한으로 특정 회원의 정보를 수정합니다. (비밀번호 변경 포함)")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/change/member/{userId}")
+    public ResponseEntity<SuccessResponse<Void>> updateMember(
+            @PathVariable Long userId,
+            @RequestBody @Valid UserDTO.Update updateDto) {
+
+        UserEntity updatedUser = userService.updateMember(userId, updateDto);
+        log.info("관리자에 의해 회원 {} 정보 수정 완료", userId);
+        return ResponseEntity.ok(SuccessResponse.of(ResponseMessage.UPDATE_SUCCESS));
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/dto/USER/UserDTO.java
+++ b/Back/src/main/java/com/mjsec/ctf/dto/USER/UserDTO.java
@@ -34,4 +34,21 @@ public class UserDTO {
         private List<String> roles; //user 또는 admin
 
     }
+    //어드민으로 계정 변경시
+    @Data
+    public static class Update {
+        // 업데이트 시 필요한 필드
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        private String email;
+        
+        @NotBlank(message = "대학 정보는 필수입니다.")
+        private String univ;
+        
+        // 로그인 아이디 업데이트
+        private String loginId;
+        
+        // 비밀번호 업데이트 (관리자에 의한 변경)
+        private String password;
+    }
 }

--- a/Back/src/main/java/com/mjsec/ctf/jwt/CustomLoginFilter.java
+++ b/Back/src/main/java/com/mjsec/ctf/jwt/CustomLoginFilter.java
@@ -87,9 +87,13 @@ public class CustomLoginFilter extends GenericFilterBean {
         // JWT 토큰 발급
         final long ACCESS_TOKEN_EXPIRY = 3600000L; // 1시간
         final long REFRESH_TOKEN_EXPIRY = 43200000L; // 12시간
-
-        String accessToken = jwtService.createJwt("accessToken", user.getLoginId(), List.of(user.getRoles()), ACCESS_TOKEN_EXPIRY);
-        String refreshToken = jwtService.createJwt("refreshToken", user.getLoginId(), List.of(user.getRoles()), REFRESH_TOKEN_EXPIRY);
+        // 관리자인 경우, 역할에 "ROLE_" 접두사를 추가하여 저장
+        String role = user.getRoles();
+        if ("admin".equalsIgnoreCase(role)) {
+            role = "ROLE_ADMIN";
+        }
+        String accessToken = jwtService.createJwt("accessToken", user.getLoginId(), List.of(role), ACCESS_TOKEN_EXPIRY);
+        String refreshToken = jwtService.createJwt("refreshToken", user.getLoginId(), List.of(role), REFRESH_TOKEN_EXPIRY);
 
         // Refresh Token 저장
         addRefreshEntity(user.getLoginId(),refreshToken,REFRESH_TOKEN_EXPIRY);

--- a/Back/src/main/java/com/mjsec/ctf/service/UserService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/UserService.java
@@ -18,6 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -118,6 +119,22 @@ public class UserService {
         response.put("user", userProfile);
 
         return response;
+    }
+     // 관리자용 회원정보 수정 메서드
+    @Transactional
+    public UserEntity updateMember(Long userId, UserDTO.Update updateDto) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.BAD_REQUEST, "해당 회원이 존재하지 않습니다."));
+        user.setEmail(updateDto.getEmail());
+        user.setUniv(updateDto.getUniv());
+        if (updateDto.getLoginId() != null && !updateDto.getLoginId().isBlank()) {
+            user.setLoginId(updateDto.getLoginId());
+        }
+        if (updateDto.getPassword() != null && !updateDto.getPassword().isBlank()) {
+            String encodedPassword = passwordEncoder.encode(updateDto.getPassword());
+            user.setPassword(encodedPassword);
+        }
+        return userRepository.save(user);
     }
 
 }

--- a/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
+++ b/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
@@ -10,6 +10,7 @@ public enum ResponseMessage {
     LOGIN_SUCCESS("로그인 성공"),
     LOGOUT_SUCCESS("로그아웃 성공"),
     PROFILE_SUCCESS("유저 프로필 조회 성공"),
+    UPDATE_SUCCESS("회원정보 수정 성공"),
     ;
 
     private final String message;

--- a/Back/src/main/resources/application.properties
+++ b/Back/src/main/resources/application.properties
@@ -1,3 +1,7 @@
 spring.profiles.active=local
 
 server.servlet.session.timeout=1800
+
+# 관리자 계정 환경변수로 주입
+spring.security.user.name=${SPRING_SECURITY_USER_NAME}
+spring.security.user.password=${SPRING_SECURITY_USER_PASSWORD}

--- a/docker-compose-backend-local.yml
+++ b/docker-compose-backend-local.yml
@@ -1,0 +1,47 @@
+version: "3.8"
+
+services:
+  db:
+    image: mysql:8.0
+    container_name: local-ctf-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - ctf-network
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: local-ctf-backend
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: local
+      DB_HOST: db
+      DB_PORT: ${DB_PORT}
+      DB_NAME: ${DB_NAME}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      SPRING_SECURITY_USER_NAME: ${SPRING_SECURITY_USER_NAME}
+      SPRING_SECURITY_USER_PASSWORD: ${SPRING_SECURITY_USER_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+    ports:
+      - "8080:8080"
+    networks:
+      - ctf-network
+
+networks:
+  ctf-network:
+    driver: bridge


### PR DESCRIPTION
# **feat: 관리자 회원정보 수정 API 추가**

- /api/admin/change/member/{userId} 엔드포인트 구현 (PUT)
- UserDTO에 Update 용 DTO 추가하여 이메일, 대학, 로그인 아이디, 비밀번호 변경 지원
- UserService에 updateMember 메서드 추가 (비밀번호 암호화 포함)
- AdminController 구현 및 @PreAuthorize("hasRole('ADMIN')") 적용
- JWT 생성 로직 수정: 관리자인 경우 "ROLE_ADMIN" 접두사 포함
- SecurityConfig 업데이트: /api/admin/** 경로에 관리자 권한 적용

관리자 계정 초기화 및 관련 보안 설정도 함께 적용함.

# 관리자 로그인 테스트 코드
```
import requests

# 1. 관리자 로그인 - 관리자 계정으로 access token 발급
login_url = "http://localhost:8080/api/users/sign-in"
login_data = {
    "loginId": "admin",         
    "password": "admin_pass"    
}

login_response = requests.post(login_url, json=login_data)
print("로그인 상태 코드:", login_response.status_code)
if login_response.status_code == 200:
    login_json = login_response.json()
    access_token = login_json.get("accessToken")
    if not access_token:
        print("accessToken이 응답에 없습니다.")
        exit(1)
    print("발급받은 accessToken:", access_token)
else:
    print("로그인 실패:", login_response.text)
    exit(1)


# 2. 관리자 API 호출 - 회원정보 수정
# ex: 관리자계정이 id가 1이니깐 관리자 본인 계정 변경

user_id = 1
update_url = f"http://localhost:8080/api/admin/change/member/{user_id}"
update_data = {
    "email": "updated_email@example.com",
    "univ": "Updated University",
    "loginId": "updatedLoginId",
    "password": "newSecurePassword"
}

headers = {
    "Content-Type": "application/json",
    "Authorization": "Bearer " + access_token
}

update_response = requests.put(update_url, json=update_data, headers=headers)
print("회원정보 수정 상태 코드:", update_response.status_code)
print("회원정보 수정 응답:", update_response.json())
```
![image](https://github.com/user-attachments/assets/2e4b3642-75a4-4fbe-aa58-5282e1342635)

# 이제 변경된 아이디/비밀번호로 로그인 코드
```
import requests

login_url = "http://localhost:8080/api/users/sign-in"


login_data = {
    "loginId": "updatedLoginId",     
    "password": "newSecurePassword"  
}

response = requests.post(login_url, json=login_data)

print("로그인 상태 코드:", response.status_code)
try:
    login_json = response.json()
    print("로그인 응답:", login_json)
    access_token = login_json.get("accessToken")
    if access_token:
        print("발급받은 accessToken:", access_token)
    else:
        print("accessToken이 응답에 없습니다.")
except Exception as e:
    print("응답 파싱 중 오류 발생:", e)
```
![image](https://github.com/user-attachments/assets/6611f349-74c4-4360-a337-6928f9cb503e)

수정사항 알려주세요...!