### PR TITLE
feat: delete/member api

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/controller/AdminController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/AdminController.java
@@ -32,4 +32,13 @@ public class AdminController {
         log.info("관리자에 의해 회원 {} 정보 수정 완료", userId);
         return ResponseEntity.ok(SuccessResponse.of(ResponseMessage.UPDATE_SUCCESS));
     }
+     // 관리자용 회원 삭제 API
+    @Operation(summary = "회원 삭제", description = "관리자 권한으로 특정 회원을 삭제합니다.")
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/delete/member/{userId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteMember(@PathVariable Long userId) {
+        userService.deleteMember(userId);
+        log.info("관리자에 의해 회원 {} 삭제 완료", userId);
+        return ResponseEntity.ok(SuccessResponse.of(ResponseMessage.DELETE_SUCCESS));
+    }
 }

--- a/Back/src/main/java/com/mjsec/ctf/service/UserService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/UserService.java
@@ -136,5 +136,10 @@ public class UserService {
         }
         return userRepository.save(user);
     }
+    public void deleteMember(Long userId) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.BAD_REQUEST, "해당 회원이 존재하지 않습니다."));
+        userRepository.delete(user);
+    }
 
 }

--- a/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
+++ b/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
@@ -11,6 +11,7 @@ public enum ResponseMessage {
     LOGOUT_SUCCESS("로그아웃 성공"),
     PROFILE_SUCCESS("유저 프로필 조회 성공"),
     UPDATE_SUCCESS("회원정보 수정 성공"),
+    DELETE_SUCCESS("회원 삭제 성공"),
     ;
 
     private final String message;


### PR DESCRIPTION
사용자 계정을 삭제하는 api를 만들었습니다.

삭제 TEST

[현 유저테이블]
![image](https://github.com/user-attachments/assets/1b9bc09e-b77e-492b-9b1c-ade22bb1d2af)

여기서 user_id 8을 지워보기
```
import requests

# 1. 관리자 로그인 - 관리자 계정으로 access token 발급
login_url = "http://localhost:8080/api/users/sign-in"
login_data = {
    "loginId": "huhuh",         # 관리자 계정 ID
    "password": "TestPass123!"      # 관리자 비밀번호
}

login_response = requests.post(login_url, json=login_data)
print("로그인 상태 코드:", login_response.status_code)
if login_response.status_code == 200:
    login_json = login_response.json()
    access_token = login_json.get("accessToken")
    if not access_token:
        print("accessToken이 응답에 없습니다.")
        exit(1)
    print("발급받은 accessToken:", access_token)
else:
    print("로그인 실패:", login_response.text)
    exit(1)
user_id = 8
delete_url = f"http://localhost:8080/api/admin/delete/member/{user_id}"

headers = {
    "Authorization": "Bearer " + access_token
}

delete_response = requests.delete(delete_url, headers=headers)
print("회원 삭제 상태 코드:", delete_response.status_code)
try:
    print("회원 삭제 응답:", delete_response.json())
except Exception as e:
    print("응답 파싱 오류:", e)
```
![image](https://github.com/user-attachments/assets/dd8ce6ea-91e6-4003-8065-717e3b66de49)
![image](https://github.com/user-attachments/assets/0b2c7bcf-f26d-449b-b537-6d06f02923b9)

