### PR TITLE
feat: api/admin/challenge/summary 구현완료

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/controller/AdminChallengeController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/AdminChallengeController.java
@@ -1,0 +1,38 @@
+package com.mjsec.ctf.controller;
+
+import com.mjsec.ctf.domain.ChallengeEntity;
+import com.mjsec.ctf.repository.ChallengeRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/admin/challenge")
+@RequiredArgsConstructor
+public class AdminChallengeController {
+
+    private final ChallengeRepository challengeRepository;
+
+    @Operation(summary = "전체 문제 요약 조회", description = "관리자 권한으로 전체 문제 목록에서 문제 번호, 제목, 포인트를 조회합니다.")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/summary")
+    public ResponseEntity<List<Map<String, Object>>> getChallengeSummary() {
+        List<ChallengeEntity> challenges = challengeRepository.findAllByOrderByChallengeIdAsc(Pageable.unpaged()).getContent();
+        List<Map<String, Object>> summaryList = challenges.stream().map(challenge -> {
+            Map<String, Object> map = new HashMap<>();
+            map.put("challengeId", challenge.getChallengeId());
+            map.put("title", challenge.getTitle());
+            map.put("points", challenge.getPoints());
+            return map;
+        }).collect(Collectors.toList());
+        return ResponseEntity.ok(summaryList);
+    }
+}


### PR DESCRIPTION
feat: api/admin/challenge/summary 구현완료

```
import requests
import os
from dotenv import load_dotenv

# .env 파일에 환경변수 설정해두었으면 불러옵니다.
load_dotenv()

# 서버 기본 URL (로컬 테스트라면 http://localhost:8080 등으로 변경)
base_url = "http://localhost:8080"

# 관리자 로그인 엔드포인트 (실제 엔드포인트에 맞게 수정)
login_url = f"{base_url}/api/users/sign-in"

# 관리자 전체 문제 조회 엔드포인트
admin_challenge_url = f"{base_url}/api/admin/challenge/summary"

# 관리자 계정 정보 (실제 값으로 대체)
admin_credentials = {
    "loginId": "admin",
    "password": "admin_pass"
}

# 1. 관리자 로그인
login_response = requests.post(login_url, json=admin_credentials)
print("Login status code:", login_response.status_code)

if login_response.status_code == 200:
    # 응답에서 JWT 토큰 추출 (응답 JSON의 key가 accessToken인지 확인)
    login_data = login_response.json()
    admin_token = login_data.get("accessToken")
    print("Admin access token:", admin_token)

    # 2. 관리자 전체 문제 조회 (요약)
    headers = {
        "Authorization": f"Bearer {admin_token}",
        "Content-Type": "application/json"
    }
    
    challenge_response = requests.get(admin_challenge_url, headers=headers)
    print("Admin Challenge API status code:", challenge_response.status_code)
    
    try:
        challenges = challenge_response.json()
        print("Challenge Data:", challenges)
    except Exception as e:
        print("Error parsing JSON:", e)
else:
    print("Login failed:", login_response.text)
```
[ 200 ok 성공]
![image](https://github.com/user-attachments/assets/c7ccadd6-4f59-4853-af3b-fb593617f626)

