### PR TITLE
feat: api/admin/challenge/{challenge_id} api 구현완료

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/controller/AdminChallengeController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/AdminChallengeController.java
@@ -8,7 +8,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
+import com.mjsec.ctf.dto.ChallengeDto;
+import com.mjsec.ctf.service.ChallengeService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,7 @@ import java.util.stream.Collectors;
 @RequestMapping("/api/admin/challenge")
 @RequiredArgsConstructor
 public class AdminChallengeController {
-
+    private final ChallengeService challengeService;
     private final ChallengeRepository challengeRepository;
 
     @Operation(summary = "전체 문제 요약 조회", description = "관리자 권한으로 전체 문제 목록에서 문제 번호, 제목, 포인트를 조회합니다.")
@@ -35,4 +36,12 @@ public class AdminChallengeController {
         }).collect(Collectors.toList());
         return ResponseEntity.ok(summaryList);
     }
+    @Operation(summary = "문제 상세 조회", description = "관리자 권한으로 특정 문제의 상세 정보를 조회합니다.")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<ChallengeDto.Detail> getChallengeDetail(@PathVariable Long challengeId) {
+        ChallengeDto.Detail detail = challengeService.getDetailChallenge(challengeId);
+        return ResponseEntity.ok(detail);
+    }
+
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b1dae719-fa92-4a0f-8e56-e7eaddbb7c81)
```
import os
import requests
from dotenv import load_dotenv

# .env 파일에서 환경변수를 로드합니다.
load_dotenv()

# 기본 서버 URL (로컬 테스트용)
BASE_URL = "http://localhost:8080"

# 관리자 로그인 엔드포인트
LOGIN_URL = f"{BASE_URL}/api/users/sign-in"

# 특정 문제 상세 조회 엔드포인트 (예시: challengeId 1)
CHALLENGE_DETAIL_URL = f"{BASE_URL}/api/admin/challenge/1"

# 관리자 계정 정보 (실제 값으로 대체)
admin_credentials = {
    "loginId": "admin",
    "password": "admin_pass"
}

# 1. 관리자 로그인
login_response = requests.post(LOGIN_URL, json=admin_credentials)
print("Login status code:", login_response.status_code)

if login_response.status_code == 200:
    login_data = login_response.json()
    admin_token = login_data.get("accessToken")
    print("Admin access token:", admin_token)
else:
    print("Login failed:", login_response.text)
    exit()

# 2. 특정 문제 상세 정보 조회
headers = {
    "Authorization": f"Bearer {admin_token}",
    "Content-Type": "application/json"
}

challenge_response = requests.get(CHALLENGE_DETAIL_URL, headers=headers)
print("Challenge detail status code:", challenge_response.status_code)

try:
    challenge_data = challenge_response.json()
    print("Challenge Data:", challenge_data)
except Exception as e:
    print("Error parsing JSON:", e)
    print("Response text:", challenge_response.text)

```