### PR TITLE
회원가입/ 이메일 확인/ 아이디 확인시 에러 코드들 추가

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/dto/USER/UserDTO.java
+++ b/Back/src/main/java/com/mjsec/ctf/dto/USER/UserDTO.java
@@ -13,25 +13,25 @@ public class UserDTO {
 
     @Data
     public static class SignIn {
-        @NotBlank(message = "로그인 아이디는 필수입니다.")
+        @NotBlank(message = "로그인 아이디를 입력해주세요.")
         private String loginId;
 
-        @NotBlank(message = "비밀번호는 필수입니다.")
+        @NotBlank(message = "비밀번호를 입력해주세요.")
         private String password;
     }
 
     @Data
     public static class SignUp {
-        @NotBlank(message = "로그인 아이디는 필수입니다.") //비밀번호 규칙 있으면 수정할 예정
+        @NotBlank(message = "로그인 아이디를 입력해주세요.") //비밀번호 규칙 있으면 수정할 예정
         private String loginId;
 
-        @NotBlank(message = "비밀번호는 필수입니다.")
+        @NotBlank(message = "비밀번호를 입력해주세요.")
         private String password;
 
-        @Email(message = "유효한 이메일 주소를 입력해주세요.")
+        @Email(message = "이메일을 입력해주세요.")
         private String email;
 
-        @NotBlank(message = "소속 학교는 필수입니다.")
+        @NotBlank(message = "학교명을 입력해주세요.")
         private String univ;
 
         private List<String> roles; //user 또는 admin

--- a/Back/src/main/java/com/mjsec/ctf/service/UserService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/UserService.java
@@ -101,6 +101,11 @@ public class UserService {
     }
 
     private void validatePassword(String password) {
+        // 공백 포함 여부 확인
+        if (Pattern.matches("\\s", password)) {
+            throw new RestApiException(ErrorCode.INVALID_PASSWORD_WHITESPACE);
+        }
+
         // 최소 길이 검사 (8자 이상)
         if (password.length() < 8) {
             throw new RestApiException(ErrorCode.INVALID_PASSWORD_LENGTH_MIN);
@@ -109,11 +114,6 @@ public class UserService {
         // 최대 길이 검사 (32자 이하)
         if (password.length() > 32) {
             throw new RestApiException(ErrorCode.INVALID_PASSWORD_LENGTH_MAX);
-        }
-
-        // 공백 포함 여부 확인
-        if (Pattern.matches("\\s", password)) {
-            throw new RestApiException(ErrorCode.INVALID_PASSWORD_WHITESPACE);
         }
 
         // 소문자, 대문자, 숫자 및 특수문자 포함 여부 확인
@@ -128,6 +128,10 @@ public class UserService {
     }
 
     public void validateLoginId(String loginId) {
+        // 공백 포함 불가
+        if (Pattern.matches("\\s", loginId)) {
+            throw new RestApiException(ErrorCode.INVALID_ID_WHITESPACE);
+        }
 
         // 길이 검사 (4~20자)
         if (loginId.length() < 4 ) {
@@ -140,11 +144,6 @@ public class UserService {
         // 영문 + 숫자만 허용
         if (!Pattern.matches("^[a-zA-Z0-9]+$", loginId)) {
             throw new RestApiException(ErrorCode.INVALID_ID_CHARACTERS);
-        }
-
-        // 공백 포함 불가
-        if (Pattern.matches("\\s", loginId)) {
-            throw new RestApiException(ErrorCode.INVALID_ID_WHITESPACE);
         }
     }
 

--- a/Back/src/main/java/com/mjsec/ctf/service/UserService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/UserService.java
@@ -23,6 +23,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -38,8 +39,19 @@ public class UserService {
     private final BlacklistedTokenRepository blacklistedTokenRepository;
     private final HistoryRepository historyRepository;
 
+    private static final String[] ALLOWED_DOMAINS = {"@mju.ac.kr", "@kku.ac.kr", "@sju.ac.kr"};
+
     //회원가입 로직
     public void signUp(UserDTO.SignUp request) {
+        //입력 모두 들어갔는지 확인
+        validateSignUp(request);
+
+        //아이디 유효성 검사
+        validateLoginId(request.getLoginId());
+
+        //비밀번호 유효성 검사
+        validatePassword(request.getPassword());
+
         if (userRepository.existsByLoginId(request.getLoginId())) {
             throw new RestApiException(ErrorCode.DUPLICATE_ID);
         }
@@ -70,8 +82,70 @@ public class UserService {
         userRepository.save(user);
     }
 
+    private void validateSignUp(UserDTO.SignUp request){
+        if (request.getLoginId() == null || request.getLoginId().trim().isEmpty()) {
+            throw new RestApiException(ErrorCode.EMPTY_LOGIN_ID);
+        }
+
+        if(request.getUniv() == null || request.getUniv().trim().isEmpty()){
+            throw new RestApiException(ErrorCode.EMPTY_UNIV);
+        }
+
+        if(request.getEmail() == null || request.getEmail().trim().isEmpty()){
+            throw new RestApiException(ErrorCode.EMPTY_EMAIL);
+        }
+
+        if(request.getPassword() == null || request.getPassword() .trim().isEmpty()){
+            throw new RestApiException(ErrorCode.EMPTY_PASSWORD);
+        }
+    }
+
+    private void validatePassword(String password) {
+        // 최소 길이 검사 (8자 이상)
+        if (password.length() < 8) {
+            throw new RestApiException(ErrorCode.INVALID_PASSWORD_LENGTH_MIN);
+        }
+
+        // 최대 길이 검사 (32자 이하)
+        if (password.length() > 32) {
+            throw new RestApiException(ErrorCode.INVALID_PASSWORD_LENGTH_MAX);
+        }
+
+        // 공백 포함 여부 확인
+        if (Pattern.matches("\\s", password)) {
+            throw new RestApiException(ErrorCode.INVALID_PASSWORD_WHITESPACE);
+        }
+
+        // 소문자, 대문자, 숫자 및 특수문자 포함 여부 확인
+        String passwordPattern = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,32}$";
+        if (!Pattern.matches(passwordPattern, password)) {
+            throw new RestApiException(ErrorCode.INVALID_PASSWORD_FORMAT);
+        }
+    }
+
     public boolean isLoginIdExists(String loginId) {
         return userRepository.existsByLoginId(loginId);
+    }
+
+    public void validateLoginId(String loginId) {
+
+        // 길이 검사 (4~20자)
+        if (loginId.length() < 4 ) {
+            throw new RestApiException(ErrorCode.INVALID_ID_LENGTH_MIN);
+        }
+        if(loginId.length() > 20){
+            throw new RestApiException(ErrorCode.INVALID_ID_LENGTH_MAX);
+        }
+
+        // 영문 + 숫자만 허용
+        if (!Pattern.matches("^[a-zA-Z0-9]+$", loginId)) {
+            throw new RestApiException(ErrorCode.INVALID_ID_CHARACTERS);
+        }
+
+        // 공백 포함 불가
+        if (Pattern.matches("\\s", loginId)) {
+            throw new RestApiException(ErrorCode.INVALID_ID_WHITESPACE);
+        }
     }
 
     public boolean isEmailExists(String email) {
@@ -190,5 +264,15 @@ public class UserService {
     public UserEntity getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.BAD_REQUEST, "해당 회원이 존재하지 않습니다."));
+    }
+
+    // 허용된 도메인인지 검증
+    public boolean isAllowedDomain(String email) {
+        for (String domain : ALLOWED_DOMAINS) {
+            if (email.endsWith(domain)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Back/src/main/java/com/mjsec/ctf/service/UserService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/UserService.java
@@ -101,8 +101,8 @@ public class UserService {
     }
 
     private void validatePassword(String password) {
-        // 공백 포함 여부 확인
-        if (Pattern.matches("\\s", password)) {
+        // 공백 포함 여부 확인 (문자열 내부나 앞뒤에 공백 포함 불가)
+        if (password.contains(" ")) {
             throw new RestApiException(ErrorCode.INVALID_PASSWORD_WHITESPACE);
         }
 
@@ -129,7 +129,7 @@ public class UserService {
 
     public void validateLoginId(String loginId) {
         // 공백 포함 불가
-        if (Pattern.matches("\\s", loginId)) {
+        if (loginId.contains(" ")) {
             throw new RestApiException(ErrorCode.INVALID_ID_WHITESPACE);
         }
 

--- a/Back/src/main/java/com/mjsec/ctf/type/ErrorCode.java
+++ b/Back/src/main/java/com/mjsec/ctf/type/ErrorCode.java
@@ -10,24 +10,43 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서부 오류가 발생했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
 
+    // 아이디 관련 에러
     DUPLICATE_ID(HttpStatus.BAD_REQUEST, "사용할 수 없는 아이디입니다."),  // 409 Conflict
+    INVALID_ID_LENGTH_MIN(HttpStatus.BAD_REQUEST, "로그인 아이디는 최소 4자 이상이어야 합니다."),
+    INVALID_ID_LENGTH_MAX(HttpStatus.BAD_REQUEST, "로그인 아이디는 20자 이하로 입력해주세요."),
+    INVALID_ID_CHARACTERS(HttpStatus.BAD_REQUEST, "로그인 아이디는 영문과 숫자만 사용할 수 있습니다."),
+    INVALID_ID_WHITESPACE(HttpStatus.BAD_REQUEST, "로그인 아이디에 공백을 포함할 수 없습니다."),
+    EMPTY_LOGIN_ID(HttpStatus.BAD_REQUEST, "로그인 아이디를 입력해주세요."),
+    INVALID_LOGIN_ID(HttpStatus.UNAUTHORIZED, "아이디를 잘못 입력하셨습니다. 다시 입력해주세요."),
+
+    // 이메일 관련 에러
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."), // 409 Conflict
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "이메일 형식에 맞지 않습니다."), // 400 Bad Request
-    UNAUTHORIZED_EMAIL(HttpStatus.BAD_REQUEST,"정해진 이메일 도메인이 아닙니다."),
+    UNAUTHORIZED_EMAIL(HttpStatus.BAD_REQUEST, "정해진 이메일 도메인이 아닙니다."),
     EMAIL_VERIFICATION_PENDING(HttpStatus.UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다. 인증을 진행해주세요."),
-    FAILED_VERIFICATION(HttpStatus.BAD_REQUEST,"인증 코드가 올바르지 않거나 만료되었습니다."),
-    AUTH_ATTEMPT_EXCEEDED(HttpStatus.BAD_REQUEST,"인증 횟수를 초과했습니다. 다시 시도해주세요."),
+    FAILED_VERIFICATION(HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않거나 만료되었습니다."),
+    AUTH_ATTEMPT_EXCEEDED(HttpStatus.BAD_REQUEST, "인증 횟수를 초과했습니다. 다시 시도해주세요."),
+    EMPTY_EMAIL(HttpStatus.BAD_REQUEST, "이메일을 입력해주세요."),
 
-
-    INVALID_LOGIN_ID(HttpStatus.UNAUTHORIZED, "아이디를 잘못 입력하셨습니다. 다시 입력해주세요."),
+    // 비밀번호 관련 에러
+    EMPTY_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호를 입력해주세요."),
+    INVALID_PASSWORD_LENGTH_MIN(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자 이상이어야 합니다."),
+    INVALID_PASSWORD_LENGTH_MAX(HttpStatus.BAD_REQUEST, "비밀번호는 32자 이하로 입력해주세요."),
+    INVALID_PASSWORD_WHITESPACE(HttpStatus.BAD_REQUEST, "비밀번호에 공백을 포함할 수 없습니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호는 소문자, 대문자, 숫자 및 특수문자(!@#$%^&*)를 모두 포함해야 합니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호를 잘못 입력하셨습니다. 다시 입력해주세요."),
 
+    // 학교명
+    EMPTY_UNIV(HttpStatus.BAD_REQUEST, "학교명을 입력해주세요."),
+
+    //문제 관련
     REQUIRED_FIELD_NULL(HttpStatus.BAD_REQUEST, "필수값이 누락되어 있습니다."),
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND,"문제 ID를 찾을 수 없습니다."),
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
-
+    
+    //유저
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.")
     ;
 


### PR DESCRIPTION
회원가입/ 이메일 확인/ 아이디 확인시 에러 코드들 추가

프론트에 맞춰서 한다고는 노력했습니다요 ...

```
INVALID_ID_LENGTH_MIN(HttpStatus.BAD_REQUEST, "로그인 아이디는 최소 4자 이상이어야 합니다."),
INVALID_ID_LENGTH_MAX(HttpStatus.BAD_REQUEST, "로그인 아이디는 20자 이하로 입력해주세요."),
INVALID_ID_CHARACTERS(HttpStatus.BAD_REQUEST, "로그인 아이디는 영문과 숫자만 사용할 수 있습니다."),
INVALID_ID_WHITESPACE(HttpStatus.BAD_REQUEST, "로그인 아이디에 공백을 포함할 수 없습니다."),
EMPTY_EMAIL(HttpStatus.BAD_REQUEST, "이메일을 입력해주세요."),
EMPTY_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호를 입력해주세요."),
INVALID_PASSWORD_LENGTH_MIN(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자 이상이어야 합니다."),
INVALID_PASSWORD_LENGTH_MAX(HttpStatus.BAD_REQUEST, "비밀번호는 32자 이하로 입력해주세요."),
INVALID_PASSWORD_WHITESPACE(HttpStatus.BAD_REQUEST, "비밀번호에 공백을 포함할 수 없습니다."),
INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호는 소문자, 대문자, 숫자 및 특수문자(!@#$%^&*)를 모두 포함해야 합니다."),
EMPTY_UNIV(HttpStatus.BAD_REQUEST, "학교명을 입력해주세요."),
```

이 정도 에러 코드 추가했다고 보면 됩니다.

postman으로 테스트했고,
노션내 API 명세 보시면 적어뒀습니다. (회원가입, 유저 아이디 확인용, 유저 이메일 확인용)

더 추가해야 할 에러코드나, 다른 피드백들 받습니다!

![image](https://github.com/user-attachments/assets/29cf6636-6b2b-4b33-8e50-3736335909f4)
