### PR TITLE
feat: History Entity, Dto, Service 에 univ 필드 추가하여 응답값에 포함

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/domain/HistoryEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/HistoryEntity.java
@@ -29,4 +29,7 @@ public class HistoryEntity {
     
  
     private LocalDateTime solvedTime;
+
+
+    private String univ; //univ 추가
 }

--- a/Back/src/main/java/com/mjsec/ctf/dto/HistoryDto.java
+++ b/Back/src/main/java/com/mjsec/ctf/dto/HistoryDto.java
@@ -12,4 +12,6 @@ public class HistoryDto {
     private String challengeId;
     private LocalDateTime solvedTime;
     private int currentScore;
+
+    private String univ;
 }

--- a/Back/src/main/java/com/mjsec/ctf/service/HistoryService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/HistoryService.java
@@ -30,12 +30,17 @@ public class HistoryService {
             ChallengeEntity challenge = challengeRepository.findById(history.getChallengeId())
                     .orElse(null);
             int dynamicScore = (challenge != null) ? challenge.getPoints() : 0;
+
+            //univ 추가
+            String univ = history.getUniv(); //엔티티에서 메서드 호출
+
             // HistoryDto의 challengeId 타입이 String인 경우 문자열로 변환합니다.
             return new HistoryDto(
                     history.getUserId(),
                     String.valueOf(history.getChallengeId()),
                     history.getSolvedTime(),
-                    dynamicScore
+                    dynamicScore,
+                    univ //univ 포함
             );
         }).collect(Collectors.toList());
     }


### PR DESCRIPTION
/graph 엔드포인트에 사용되는

History Entity, Dto, Service 에 univ 추가하였습니다.
/graph 엔드포인트 sse 통신 응답값에 univ 포함됩니다.

대학별 합산 점수는 프론트에서 univ 분류로 계산 가능합니다.