### PR TITLE
Feature/solved : add /api/users/challenges api for get list of history what user solved

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/controller/UserController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.mjsec.ctf.controller;
 
 import com.mjsec.ctf.domain.UserEntity;
+import com.mjsec.ctf.dto.HistoryDto;
 import com.mjsec.ctf.dto.SuccessResponse;
 import com.mjsec.ctf.dto.user.UserDTO;
 import com.mjsec.ctf.exception.RestApiException;
@@ -11,8 +12,10 @@ import com.mjsec.ctf.service.UserService;
 import com.mjsec.ctf.type.ErrorCode;
 import com.mjsec.ctf.type.ResponseMessage;
 import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
@@ -115,5 +118,28 @@ public class UserController {
         } else {
             throw new RestApiException(ErrorCode.FAILED_VERIFICATION);
         }
+    }
+
+    @Operation(summary = "히스토리 리스트", description = "유저별 푼 문제 리스트 확인")
+    @GetMapping("/challenges")
+    public ResponseEntity<SuccessResponse<List<HistoryDto>>> getChallengeHistory(
+            @RequestHeader(value = "Authorization") String token) {
+
+        if (token == null || !token.startsWith("Bearer ")) {
+            log.error("Authorization header is missing or invalid: {}", token);
+            throw new RestApiException(ErrorCode.UNAUTHORIZED);
+        }
+
+        String accessToken = token.substring(7);
+        log.info("Extracted Access Token for profile: {}", accessToken);
+
+        List<HistoryDto> history = userService.getChallengeHistory(accessToken);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessResponse.of(
+                        ResponseMessage.GET_HISTORY_SUCCESS,
+                        history
+                )
+        );
     }
 }

--- a/Back/src/main/java/com/mjsec/ctf/domain/ChallengeEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/ChallengeEntity.java
@@ -3,6 +3,7 @@ package com.mjsec.ctf.domain;
 import com.mjsec.ctf.type.ChallengeCategory;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -57,7 +58,8 @@ public class ChallengeEntity extends BaseEntity {
     private String url;
 
     @Column(nullable = false)
-    private int solvers =0;
+    @Builder.Default
+    private int solvers = 0;
 
     // 문제 카테고리 추가 (enum 타입)
     @Column(nullable = false)

--- a/Back/src/main/java/com/mjsec/ctf/dto/HistoryDto.java
+++ b/Back/src/main/java/com/mjsec/ctf/dto/HistoryDto.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 public class HistoryDto {
     private String userId;
     private String challengeId;
+    private String title;
     private LocalDateTime solvedTime;
     private int currentScore;
 

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -209,6 +209,9 @@ public class ChallengeService {
             }
     
             updateChallengeScore(challenge);
+
+            challenge.setSolvers(challenge.getSolvers() + 1);
+            challengeRepository.save(challenge);
     
             return "Correct";
         }

--- a/Back/src/main/java/com/mjsec/ctf/service/HistoryService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/HistoryService.java
@@ -38,6 +38,7 @@ public class HistoryService {
             return new HistoryDto(
                     history.getUserId(),
                     String.valueOf(history.getChallengeId()),
+                    challenge.getTitle(),
                     history.getSolvedTime(),
                     dynamicScore,
                     univ //univ 포함

--- a/Back/src/main/java/com/mjsec/ctf/service/UserService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/UserService.java
@@ -180,12 +180,8 @@ public class UserService {
         UserEntity user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.BAD_REQUEST));
 
-        // 유저가 푼 문제 리스트 조회
-        List<HistoryEntity> historyEntities = historyRepository.findByUserId(user.getLoginId());
-
         // 프로필 정보 반환
         Map<String, Object> userProfile = new HashMap<>();
-
         userProfile.put("user_id", user.getUserId());
         userProfile.put("email", user.getEmail());
         userProfile.put("univ", user.getUniv());

--- a/Back/src/main/java/com/mjsec/ctf/service/UserService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/UserService.java
@@ -180,7 +180,6 @@ public class UserService {
         List<HistoryEntity> historyEntities = historyRepository.findByUserId(user.getLoginId());
 
         // 프로필 정보 반환
-        Map<String, Object> response = new HashMap<>();
         Map<String, Object> userProfile = new HashMap<>();
 
         userProfile.put("user_id", user.getUserId());
@@ -191,13 +190,9 @@ public class UserService {
         userProfile.put("created_at", user.getCreatedAt());
         userProfile.put("updated_at", user.getUpdatedAt());
 
-        //유저가 푼 문제 추가 (임시)
-        response.put("history", historyEntities);
-
-        response.put("user", userProfile);
-
-        return response;
+        return userProfile;
     }
+
      // 관리자용 회원정보 수정 메서드
     @Transactional
     public UserEntity updateMember(Long userId, UserDTO.Update updateDto) {

--- a/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
+++ b/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
@@ -19,6 +19,7 @@ public enum ResponseMessage {
     GET_ALL_CHALLENGE_SUCCESS("모든 문제 조회 성공"),
     GET_CHALLENGE_DETAIL_SUCCESS("특정 문제 상세 정보 조회 성공"),
     SUBMIT_SUCCESS("문제 제출 성공"),
+    GET_HISTORY_SUCCESS("히스토리 조회 성공"),
     ;
 
     private final String message;


### PR DESCRIPTION
## 변경사항

- 프로필 조회 api에서 사용하는 UserService.getProfile 메서드 내에서 히스토리를 제외한 값들을 반환하도록 변경하였습니다.
<img width="812" alt="스크린샷 2025-03-05 오후 4 43 51" src="https://github.com/user-attachments/assets/12d42117-b037-432b-9e4e-e31d6a3352c9" />

- 히스토리 조회를 위해 히스토리 Dto에 문제 제목(title)을 추가하였습니다.
<img width="355" alt="스크린샷 2025-03-05 오후 4 44 41" src="https://github.com/user-attachments/assets/ae4a619e-af02-4ec7-8da1-d9ae435c30c7" />

- ResponseMessage에 GET_HISTORY_SUCCESS("히스토리 조회 성공") 를 추가하였습니다.

- /api/users/challenges(유저가 푼 문제 리스트 조회 (히스토리)) 를 위해 컨트롤러와 서비스 레이어에 메서드를 추가하였습니다.
<img width="725" alt="스크린샷 2025-03-05 오후 4 46 51" src="https://github.com/user-attachments/assets/ab7b922a-8675-4796-811c-e7bb8375ff0a" />
토큰 검증이 이루어지고 레포지토리에서 유저를 불러옵니다.
<img width="904" alt="스크린샷 2025-03-05 오후 4 47 38" src="https://github.com/user-attachments/assets/63a16028-1358-48ec-977b-e657200f2f21" />
