### PR TITLE
feat: add univ Column mapping

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/domain/HistoryEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/HistoryEntity.java
@@ -30,6 +30,6 @@ public class HistoryEntity {
  
     private LocalDateTime solvedTime;
 
-
+    @Column(name = "univ")
     private String univ; //univ 추가
 }


### PR DESCRIPTION
univ 값이 null 로 넘어오는 상황 확인하였습니다.

서버 DB 의 컬럼명과 매핑되지 않아 생기는 문제라고 파악되어

@Column(name = "univ")
추가하여 univ 컬럼과 historyEntity 의 univ 매핑시켰습니다.