### PR TITLE
feat/univ challege service 에서 univ정보도 전달

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -199,6 +199,7 @@ public class ChallengeService {
                     .userId(user.getLoginId())
                     .challengeId(challenge.getChallengeId())
                     .solvedTime(LocalDateTime.now())
+                    .univ(user.getUniv())
                     .build();
     
             historyRepository.save(history);


### PR DESCRIPTION
challenge service에서 univ정보가 전달이 안돼서 null로 표시되는거 해결해보고자 합니다.