### PR TITLE
feat: Problem 삭제시 history 엔티티도 제거

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
+++ b/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
 
 @Repository
 public interface HistoryRepository extends JpaRepository<HistoryEntity, Long> {

--- a/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
+++ b/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
@@ -23,4 +23,10 @@ public interface HistoryRepository extends JpaRepository<HistoryEntity, Long> {
 
     @Query("SELECT DISTINCT h.userId FROM HistoryEntity h")
     List<String> findDistinctUserIds();
+
+     // challengeId에 해당하는 HistoryEntity를 삭제하는 메서드
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM HistoryEntity h WHERE h.challengeId = :challengeId")
+    void deleteByChallengeId(@Param("challengeId") Long challengeId);
 }

--- a/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
+++ b/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
@@ -31,4 +31,10 @@ public interface HistoryRepository extends JpaRepository<HistoryEntity, Long> {
     @Modifying
     @Query("DELETE FROM HistoryEntity h WHERE h.challengeId = :challengeId")
     void deleteByChallengeId(@Param("challengeId") Long challengeId);
+
+    // userId에 해당하는 HistoryEntity를 삭제하는 메서드
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM HistoryEntity h WHERE h.userId = :userId")
+    void deleteByUserId(@Param("userId") String userId);
 }

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -157,6 +157,8 @@ public class ChallengeService {
 
         ChallengeEntity challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CHALLENGE_NOT_FOUND));
+        // 해당 challenge_id에 해당하는 history 레코드를 먼저 삭제
+        historyRepository.deleteByChallengeId(challengeId);
         
         challengeRepository.delete(challenge);
     }

--- a/Back/src/main/java/com/mjsec/ctf/service/UserService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/UserService.java
@@ -222,6 +222,9 @@ public class UserService {
     public void deleteMember(Long userId) {
         UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.BAD_REQUEST, "해당 회원이 존재하지 않습니다."));
+        
+        // 회원의 로그인 ID를 기준으로 히스토리 삭제
+        historyRepository.deleteByUserId(user.getLoginId());
         userRepository.delete(user);
     }
 


### PR DESCRIPTION
Problem 삭제할 때 해당 삭제하는 challenge_id 랑 같은 제출기록을 제거하기 위해 histroy 엔티티에서도 삭제처리하여 엔티티 간 연관 관계 추가했습니다.