### PR TITLE
fix(get-all-challenges): add boolean value 'solved' in ChallengeDto.Simple

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/dto/ChallengeDto.java
+++ b/Back/src/main/java/com/mjsec/ctf/dto/ChallengeDto.java
@@ -49,14 +49,16 @@ public class ChallengeDto {
         private int solvers;
         private String title;
         private String category;
+        private boolean solved;
 
-        public static Simple fromEntity(ChallengeEntity challenge) {
+        public static Simple fromEntity(ChallengeEntity challenge, boolean solved) {
             return Simple.builder()
                     .challengeId(challenge.getChallengeId())
                     .title(challenge.getTitle())
                     .points(challenge.getPoints())
                     .solvers(challenge.getSolvers())
                     .category(challenge.getCategory() != null ? challenge.getCategory().toString() : null)
+                    .solved(solved)
                     .build();
         }
     }


### PR DESCRIPTION
## 변경사항

- ChallengeDto : 사용자가 모든 문제 리스트를 조회할 때 정답 처리된 문제는 true로, 풀지 않은 문제는 false라는 값을 반환하도록 'solved'변수를 Dto에 추가하였습니다.
<img width="873" alt="스크린샷 2025-03-08 오후 5 31 11" src="https://github.com/user-attachments/assets/4bb45894-20d4-482e-9852-66e443b2f106" />

- ChallengeService : history 테이블에서 풀이 여부를 확인하기 위해 현재 사용자의 loginId를 반환하는 메소드를 추가하였습니다. 
- /api/challenges/all 요청을 보낼 때 access 토큰을 넣어서 보내기 때문에 토큰에서 loginId를 추출해도 되지만, SecurityContextHolder에서 도 추출이 되기에 기존 코드 변경을 최소화하였습니다.
<img width="866" alt="스크린샷 2025-03-08 오후 5 32 39" src="https://github.com/user-attachments/assets/4bbcf7f8-753d-4f9f-80cf-49d51a7d1184" />

- ChallengeService : 모든 문제를 리스트화하는 메소드에 풀이 여부를 확인하는 로직을 추가하였습니다.
<img width="958" alt="스크린샷 2025-03-08 오후 5 36 30" src="https://github.com/user-attachments/assets/a34ce931-b8ef-4adf-9f6c-b34e10f78519" />

## 테스트
- PostMan 테스트
<img width="804" alt="스크린샷 2025-03-08 오후 5 37 38" src="https://github.com/user-attachments/assets/f49c9022-d389-4163-aa95-5e5ac4d459c6" />
