### PR TITLE
feat(filter): add access control filter for ctf start time and end time

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/config/FilterConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/FilterConfig.java
@@ -1,0 +1,34 @@
+package com.mjsec.ctf.config;
+
+import com.mjsec.ctf.filter.AccessControlFilter;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<AccessControlFilter> accessControlFilter() {
+
+        FilterRegistrationBean<AccessControlFilter> registrationBean = new FilterRegistrationBean<>();
+
+        ZonedDateTime startTime = ZonedDateTime.of(
+                LocalDateTime.of(2025, 3, 29, 10, 0),
+                ZoneId.of("Asia/Seoul")
+        );
+
+        ZonedDateTime endTime = ZonedDateTime.of(
+                LocalDateTime.of(2025, 3, 29, 22, 0),
+                ZoneId.of("Asia/Seoul")
+        );
+
+        registrationBean.setFilter(new AccessControlFilter(startTime, endTime));
+        registrationBean.addUrlPatterns("/*");
+
+        return registrationBean;
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
@@ -1,22 +1,19 @@
 package com.mjsec.ctf.config;
 
-import com.mjsec.ctf.jwt.CustomLoginFilter;
-import com.mjsec.ctf.jwt.CustomLogoutFilter;
+import com.mjsec.ctf.filter.CustomLoginFilter;
+import com.mjsec.ctf.filter.CustomLogoutFilter;
 import com.mjsec.ctf.repository.BlacklistedTokenRepository;
 import com.mjsec.ctf.repository.RefreshRepository;
 import com.mjsec.ctf.repository.UserRepository;
-import com.mjsec.ctf.security.JwtFilter;
+import com.mjsec.ctf.filter.JwtFilter;
 import com.mjsec.ctf.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
-import java.util.Collections;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;

--- a/Back/src/main/java/com/mjsec/ctf/filter/AccessControlFilter.java
+++ b/Back/src/main/java/com/mjsec/ctf/filter/AccessControlFilter.java
@@ -36,6 +36,7 @@ public class AccessControlFilter implements Filter {
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
         String requestURI = httpRequest.getRequestURI();
 
+        /* 개발 기간 중에는 주석처리
         if(now.isBefore(startTime) && !allowedBeforeStartPattern.matcher(requestURI).matches()){
             httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
             httpResponse.getWriter().write("This site is not available until " + startTime);
@@ -46,7 +47,7 @@ public class AccessControlFilter implements Filter {
             httpResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             httpResponse.getWriter().write("Submit is not allowed after " + endTime);
             return;
-        }
+        */
 
         chain.doFilter(request, response);
     }

--- a/Back/src/main/java/com/mjsec/ctf/filter/AccessControlFilter.java
+++ b/Back/src/main/java/com/mjsec/ctf/filter/AccessControlFilter.java
@@ -1,0 +1,53 @@
+package com.mjsec.ctf.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.regex.Pattern;
+
+public class AccessControlFilter implements Filter {
+
+    private final ZonedDateTime startTime;
+    private final ZonedDateTime endTime;
+    private final Pattern allowedBeforeStartPattern;
+    private final Pattern submitPattern;
+
+    public AccessControlFilter(ZonedDateTime startTime, ZonedDateTime endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.allowedBeforeStartPattern = Pattern.compile("^/api/users/(sign-in|sign-up)$");
+        this.submitPattern = Pattern.compile("^/api/challenges/\\d+/submit$");
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        String requestURI = httpRequest.getRequestURI();
+
+        if(now.isBefore(startTime) && !allowedBeforeStartPattern.matcher(requestURI).matches()){
+            httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            httpResponse.getWriter().write("This site is not available until " + startTime);
+            return;
+        }
+
+        if(now.isAfter(endTime) && submitPattern.matcher(requestURI).matches()){
+            httpResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            httpResponse.getWriter().write("Submit is not allowed after " + endTime);
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/Back/src/main/java/com/mjsec/ctf/filter/CustomLoginFilter.java
+++ b/Back/src/main/java/com/mjsec/ctf/filter/CustomLoginFilter.java
@@ -1,4 +1,4 @@
-package com.mjsec.ctf.jwt;
+package com.mjsec.ctf.filter;
 
 import com.mjsec.ctf.domain.RefreshEntity;
 import com.mjsec.ctf.dto.user.UserDTO;

--- a/Back/src/main/java/com/mjsec/ctf/filter/CustomLogoutFilter.java
+++ b/Back/src/main/java/com/mjsec/ctf/filter/CustomLogoutFilter.java
@@ -1,4 +1,4 @@
-package com.mjsec.ctf.jwt;
+package com.mjsec.ctf.filter;
 
 import com.mjsec.ctf.domain.BlacklistedTokenEntity;
 import com.mjsec.ctf.domain.BlacklistedTokenEntity;

--- a/Back/src/main/java/com/mjsec/ctf/filter/JwtFilter.java
+++ b/Back/src/main/java/com/mjsec/ctf/filter/JwtFilter.java
@@ -1,4 +1,4 @@
-package com.mjsec.ctf.security;
+package com.mjsec.ctf.filter;
 
 import com.mjsec.ctf.repository.BlacklistedTokenRepository;
 import com.mjsec.ctf.service.JwtService;


### PR DESCRIPTION
## 변경사항

- FilterConfig : startTime과 endTime을 설정해두었습니다.
<img width="841" alt="스크린샷 2025-03-13 오전 11 29 25" src="https://github.com/user-attachments/assets/7eb1e080-b271-46a5-8b75-3b428f93787d" />

- AccessControlFilter : 대회 시작 전에는 /api/users/sign-up, /api/users/sign-in 에만 접근할 수 있도록 필터를 구현하였습니다.
<img width="768" alt="스크린샷 2025-03-13 오전 11 30 35" src="https://github.com/user-attachments/assets/7b4da11d-6bdc-4e2b-b881-aeb214437bea" />
<img width="758" alt="스크린샷 2025-03-13 오전 11 30 22" src="https://github.com/user-attachments/assets/141b67ae-70e4-483f-b1f5-f827cd8b164f" />

- AccessControlFilter : 대회가 끝난 후에는 제출을 할 수 없도록 필터를 구현하였습니다.
<img width="654" alt="스크린샷 2025-03-13 오전 11 31 27" src="https://github.com/user-attachments/assets/32e1ea6e-79d6-4429-ad91-52527c4e6f93" />
<img width="686" alt="스크린샷 2025-03-13 오전 11 31 39" src="https://github.com/user-attachments/assets/5781781b-3d60-49b0-a5a6-f7fc9ee1426c" />

## 테스트 : Postman

대회시작 전에 회원가입 / 로그인 이외의 API에 접근할 경우
<img width="493" alt="스크린샷 2025-03-13 오전 11 32 45" src="https://github.com/user-attachments/assets/bfe062d0-791c-40ca-8a14-c97e11d16187" />

대회가 끝난 후에 제출을 할 경우
<img width="817" alt="스크린샷 2025-03-13 오전 11 33 32" src="https://github.com/user-attachments/assets/e232f5eb-d73e-41a3-b3a5-055eba874a4c" />


