### PR TITLE
feat(submit penalty): add submission entity and repository for brute force penalty check

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/controller/ChallengeController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/ChallengeController.java
@@ -94,11 +94,34 @@ public class ChallengeController {
 
         String result = challengeService.submit(loginId, challengeId, flag);
 
-        return ResponseEntity.status(HttpStatus.OK).body(
-                SuccessResponse.of(
-                        ResponseMessage.SUBMIT_SUCCESS,
-                        result
-                )
-        );
+        if(result.equals("Correct")) {
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    SuccessResponse.of(
+                            ResponseMessage.SUBMIT_SUCCESS,
+                            result
+                    )
+            );
+        } else if (result.equals("Submitted")) {
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    SuccessResponse.of(
+                            ResponseMessage.ALREADY_SUBMITTED,
+                            result
+                    )
+            );
+        } else if (result.equals("Wait")) {
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    SuccessResponse.of(
+                            ResponseMessage.SUBMIT_FAILED_WAIT,
+                            result
+                    )
+            );
+        } else {
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    SuccessResponse.of(
+                            ResponseMessage.SUBMIT_FAILED_WRONG,
+                            result
+                    )
+            );
+        }
     }
 }

--- a/Back/src/main/java/com/mjsec/ctf/domain/ChallengeEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/ChallengeEntity.java
@@ -30,7 +30,7 @@ public class ChallengeEntity extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 300)
     private String description;
 
     @Column(nullable = false)
@@ -54,7 +54,7 @@ public class ChallengeEntity extends BaseEntity {
     @Column
     private String fileUrl;
 
-    @Column
+    @Column(length = 300)
     private String url;
 
     @Column(nullable = false)

--- a/Back/src/main/java/com/mjsec/ctf/domain/SubmissionEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/SubmissionEntity.java
@@ -1,0 +1,38 @@
+package com.mjsec.ctf.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubmissionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String loginId;
+
+    @Column
+    private Long challengeId;
+
+    @Column
+    private int attemptCount;
+
+    @Column
+    private LocalDateTime lastAttemptTime;
+}

--- a/Back/src/main/java/com/mjsec/ctf/repository/SubmissionRepository.java
+++ b/Back/src/main/java/com/mjsec/ctf/repository/SubmissionRepository.java
@@ -1,0 +1,12 @@
+package com.mjsec.ctf.repository;
+
+import com.mjsec.ctf.domain.SubmissionEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubmissionRepository extends JpaRepository<SubmissionEntity, Long> {
+
+    Optional<SubmissionEntity> findByLoginIdAndChallengeId(String loginId, Long challengeId);
+}

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -2,11 +2,13 @@ package com.mjsec.ctf.service;
 
 import com.mjsec.ctf.domain.ChallengeEntity;
 import com.mjsec.ctf.domain.HistoryEntity;
+import com.mjsec.ctf.domain.SubmissionEntity;
 import com.mjsec.ctf.domain.UserEntity;
 import com.mjsec.ctf.dto.ChallengeDto;
 import com.mjsec.ctf.exception.RestApiException;
 import com.mjsec.ctf.repository.ChallengeRepository;
 import com.mjsec.ctf.repository.HistoryRepository;
+import com.mjsec.ctf.repository.SubmissionRepository;
 import com.mjsec.ctf.repository.UserRepository;
 import com.mjsec.ctf.repository.LeaderboardRepository;
 import com.mjsec.ctf.type.ErrorCode;
@@ -14,6 +16,7 @@ import io.micrometer.common.util.StringUtils;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +46,7 @@ public class ChallengeService {
     private final UserRepository userRepository;
     private final HistoryRepository historyRepository;
     private final LeaderboardRepository leaderboardRepository;
+    private final SubmissionRepository submissionRepository;
 
     @Value("${api.key}")
     private String apiKey;
@@ -208,8 +212,29 @@ public class ChallengeService {
     
         ChallengeEntity challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CHALLENGE_NOT_FOUND));
-    
+
+        SubmissionEntity submission = submissionRepository.findByLoginIdAndChallengeId(loginId, challengeId)
+                .orElseGet(() -> {
+                    SubmissionEntity newSubmission = SubmissionEntity.builder()
+                            .loginId(loginId)
+                            .challengeId(challengeId)
+                            .attemptCount(0)
+                            .lastAttemptTime(LocalDateTime.now())
+                            .build();
+                    return newSubmission;
+                });
+
+        long secondsSinceLastAttempt = ChronoUnit.SECONDS.between(submission.getLastAttemptTime(), LocalDateTime.now());
+
+        if(submission.getAttemptCount() >= 3 && secondsSinceLastAttempt < 30){
+            return "You must wait " + (30 - secondsSinceLastAttempt) + " seconds before trying again.";
+        }
+
         if(!Objects.equals(flag, challenge.getFlag())){
+            submission.setAttemptCount(submission.getAttemptCount() + 1);
+            submission.setLastAttemptTime(LocalDateTime.now());
+            submissionRepository.save(submission);
+
             return "Wrong";
         } else {
             if(historyRepository.existsByUserIdAndChallengeId(user.getLoginId(), challengeId)){
@@ -236,6 +261,8 @@ public class ChallengeService {
             challengeRepository.save(challenge);
 
             afterSubmit();
+
+            submissionRepository.delete(submission);
 
             return "Correct";
         }

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -227,7 +227,7 @@ public class ChallengeService {
         long secondsSinceLastAttempt = ChronoUnit.SECONDS.between(submission.getLastAttemptTime(), LocalDateTime.now());
 
         if(submission.getAttemptCount() >= 3 && secondsSinceLastAttempt < 30){
-            return "You must wait " + (30 - secondsSinceLastAttempt) + " seconds before trying again.";
+            return "Wait";
         }
 
         if(!Objects.equals(flag, challenge.getFlag())){
@@ -238,7 +238,7 @@ public class ChallengeService {
             return "Wrong";
         } else {
             if(historyRepository.existsByUserIdAndChallengeId(user.getLoginId(), challengeId)){
-                return "Already submitted";
+                return "Submitted";
             }
     
             HistoryEntity history = HistoryEntity.builder()

--- a/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
+++ b/Back/src/main/java/com/mjsec/ctf/type/ResponseMessage.java
@@ -18,7 +18,10 @@ public enum ResponseMessage {
     DELETE_CHALLENGE_SUCCESS("문제 삭제 성공"),
     GET_ALL_CHALLENGE_SUCCESS("모든 문제 조회 성공"),
     GET_CHALLENGE_DETAIL_SUCCESS("특정 문제 상세 정보 조회 성공"),
-    SUBMIT_SUCCESS("문제 제출 성공"),
+    SUBMIT_SUCCESS("정답"),
+    SUBMIT_FAILED_WRONG("오답"),
+    SUBMIT_FAILED_WAIT("브루트포스 금지"),
+    ALREADY_SUBMITTED("이미 정답처리 된 문제"),
     GET_HISTORY_SUCCESS("히스토리 조회 성공"),
     ;
 


### PR DESCRIPTION
## 변경사항

Challenge 엔티티의 description, url 컬럼에 length를 설정해주었습니다.
<img width="341" alt="스크린샷 2025-03-15 오후 5 41 42" src="https://github.com/user-attachments/assets/5079449a-6d57-4797-a817-8b2f2de741e1" />
<img width="208" alt="스크린샷 2025-03-15 오후 5 41 53" src="https://github.com/user-attachments/assets/e5b08ce0-d686-4503-ab65-2d6b84794a94" />

브루트 포스를 이용한 정답 제출을 막기 위해 submission 엔티티와 레포지토리를 만들었습니다.
<img width="470" alt="스크린샷 2025-03-15 오후 5 43 03" src="https://github.com/user-attachments/assets/41e66464-59e1-4851-8ec6-8159ffcb7e06" />
<img width="793" alt="스크린샷 2025-03-15 오후 5 43 17" src="https://github.com/user-attachments/assets/8e32f497-775d-41de-8b5a-b637b4e67fc0" />

chllenge 서비스 코드에서 이전 제출 기록이 없는 사용자라면 submission 엔티티를 새로 만들고, 제출 횟수와 마지막 제출 시간 기준 30초가 경과하였는지 체크 후 flag에 대한 정답 여부를 판별합니다.
<img width="955" alt="스크린샷 2025-03-15 오후 5 44 57" src="https://github.com/user-attachments/assets/88c1927f-8af1-457b-8319-78d1b1b8fdfe" />

정답이 아니라면 제출 횟수 count를 올리고 마지막 제출 시간을 저장한 뒤에 Wrong이라는 문자열을 반환합니다.
<img width="561" alt="스크린샷 2025-03-15 오후 5 45 36" src="https://github.com/user-attachments/assets/5fae8c31-6360-4991-96e3-bc0d1a265530" />

결국 문제 제출 api 호출 시, Correct, Submitted, Wait, Wrong 총 4가지의 문자열 중 하나를 반환 받게 됩니다.

## 테스트 : Postman
<img width="807" alt="스크린샷 2025-03-15 오후 5 32 24" src="https://github.com/user-attachments/assets/0f53e294-c34f-4658-827b-678da59b5501" />
<img width="807" alt="스크린샷 2025-03-15 오후 5 32 42" src="https://github.com/user-attachments/assets/41517566-aa55-4b3f-aece-932672246808" />
<img width="808" alt="스크린샷 2025-03-15 오후 5 34 02" src="https://github.com/user-attachments/assets/8af41abe-3e7f-4113-8280-88a5b3b74c5f" />
<img width="805" alt="스크린샷 2025-03-15 오후 5 34 16" src="https://github.com/user-attachments/assets/5515a5a1-ab79-4c72-9a3a-55d9cf429759" />
