### PR TITLE
fix(delete-challenge): set total points of user entity and leaderboard if challenge deleted

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/repository/UserRepository.java
+++ b/Back/src/main/java/com/mjsec/ctf/repository/UserRepository.java
@@ -1,7 +1,9 @@
 package com.mjsec.ctf.repository;
 
 import com.mjsec.ctf.domain.UserEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
@@ -11,5 +13,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     boolean existsByEmail(String email);
 
     Optional<UserEntity> findByLoginId(String loginId);// 로그인 ID로 유저 조회
-    Optional<UserEntity> findByEmail(String email);
+
+    @Query("SELECT u.loginId FROM UserEntity u")
+    List<String> findAllUserLoginIds();
 }

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -385,8 +385,11 @@ public class ChallengeService {
                         .orElseThrow(() -> new RestApiException(ErrorCode.LEADERBOARD_NOT_FOUND));
 
                 leaderboard.setTotalPoint(0);
+                leaderboard.setLastSolvedTime(null);
                 leaderboardRepository.save(leaderboard);
             }
+
+            return;
         }
 
         for (String userId : userIds) {

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -5,6 +5,7 @@ import com.mjsec.ctf.domain.HistoryEntity;
 import com.mjsec.ctf.domain.SubmissionEntity;
 import com.mjsec.ctf.domain.UserEntity;
 import com.mjsec.ctf.dto.ChallengeDto;
+import com.mjsec.ctf.entity.Leaderboard;
 import com.mjsec.ctf.exception.RestApiException;
 import com.mjsec.ctf.repository.ChallengeRepository;
 import com.mjsec.ctf.repository.HistoryRepository;
@@ -369,6 +370,24 @@ public class ChallengeService {
     public void updateTotalPoints () {
 
         List<String> userIds = historyRepository.findDistinctUserIds();
+
+        if(userIds.isEmpty()){
+            List<String> userLoginIds = userRepository.findAllUserLoginIds();
+
+            for(String loginId : userLoginIds){
+                UserEntity user = userRepository.findByLoginId(loginId)
+                        .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
+
+                user.setTotalPoint(0);
+                userRepository.save(user);
+
+                Leaderboard leaderboard = leaderboardRepository.findByUserId(user.getLoginId())
+                        .orElseThrow(() -> new RestApiException(ErrorCode.LEADERBOARD_NOT_FOUND));
+
+                leaderboard.setTotalPoint(0);
+                leaderboardRepository.save(leaderboard);
+            }
+        }
 
         for (String userId : userIds) {
             List<HistoryEntity> userHistoryList = historyRepository.findByUserId(userId);

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -181,6 +181,8 @@ public class ChallengeService {
         historyRepository.deleteByChallengeId(challengeId);
         
         challengeRepository.delete(challenge);
+
+        updateTotalPoints();
     }
 
     // 문제 파일 다운로드
@@ -260,7 +262,7 @@ public class ChallengeService {
             challenge.setSolvers(challenge.getSolvers() + 1);
             challengeRepository.save(challenge);
 
-            afterSubmit();
+            updateTotalPoints();
 
             submissionRepository.delete(submission);
 
@@ -364,7 +366,7 @@ public class ChallengeService {
         }
     }
 
-    public void afterSubmit() {
+    public void updateTotalPoints () {
 
         List<String> userIds = historyRepository.findDistinctUserIds();
 

--- a/Back/src/main/java/com/mjsec/ctf/type/ErrorCode.java
+++ b/Back/src/main/java/com/mjsec/ctf/type/ErrorCode.java
@@ -48,7 +48,8 @@ public enum ErrorCode {
     
     //유저
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
-    INVALID_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 역할입니다.");
+    INVALID_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 역할입니다."),
+    LEADERBOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "유저에 대한 리더보드를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 변경사항

ChallengeService 코드 내부의 afterSubmit 메서드의 이름을 updateTotalPoints로 바꾸었습니다.(사용자가 문제 제출을 할 떄 뿐만아니라 관리자가 문제를 삭제할 때도 사용하기 위함)
<img width="320" alt="스크린샷 2025-03-17 오후 12 11 52" src="https://github.com/user-attachments/assets/afae5bbe-5176-44e3-b1aa-c4fd4fddfe39" />


문제를 삭제시킬 때 유저 엔티티의 totalPoints와 리더보드 엔티티의 totalPoints를 업데이트 합니다.
<img width="728" alt="스크린샷 2025-03-17 오후 12 12 12" src="https://github.com/user-attachments/assets/c1472a0b-a30f-4966-b300-c6ad3f5ae479" />


문제를 삭제시킬 때 먼저 history와 challenge를 삭제하고 updateTotalPoints 메소드를 호출하게 됩니다.
다만 전체 사용자에 대한 점수를 업데이트 할 때 히스토리 레포지토리를 참조하기 때문에, 문제 전체가 삭제되어 남아있지 않은 경우 메서드 내부 for문으로 들어가지 못하는 문제가 있었습니다.
<img width="579" alt="스크린샷 2025-03-17 오후 12 15 57" src="https://github.com/user-attachments/assets/5518350f-d786-4dcd-9ab8-c041a935b9d2" />
<img width="726" alt="스크린샷 2025-03-17 오후 12 16 09" src="https://github.com/user-attachments/assets/515d37b3-d176-43b1-a19b-51ca63da84a9" />
따라서 history 레포지토리에서 중복없이 불러온 사용자의 id 리스트가 empty라면, 모든 유저의 user 엔티티와 리더보드 엔티티의 totalPoints가 0이 되도록 설정하였습니다.
<img width="782" alt="스크린샷 2025-03-17 오후 12 18 27" src="https://github.com/user-attachments/assets/51735304-a4e8-4798-b618-ebc4dd632715" />


## 테스트 : Postman & MySQL Workbench

문제 삭제 후(전체 문제 삭제) user 엔티티
<img width="998" alt="스크린샷 2025-03-17 오후 12 21 42" src="https://github.com/user-attachments/assets/d488c8bd-cfa0-4a80-9a76-24c87d69a236" />


문제 삭제 후(전체 문제 삭제) history 엔티티
<img width="337" alt="스크린샷 2025-03-17 오후 12 19 28" src="https://github.com/user-attachments/assets/d5c39b3a-c68d-4c50-bb05-45db0d76b32b" />


문제 삭제 후(전체 문제 삭제) leaderboard 엔티티
<img width="416" alt="스크린샷 2025-03-17 오후 12 20 56" src="https://github.com/user-attachments/assets/e17960de-16e4-4211-a262-bcd4412e0380" />

