### PR TITLE
fix: jwt reissue, submission

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/controller/LeaderboardController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/LeaderboardController.java
@@ -1,7 +1,7 @@
 package com.mjsec.ctf.controller;
 
 import com.mjsec.ctf.dto.HistoryDto;
-import com.mjsec.ctf.entity.Leaderboard;
+import com.mjsec.ctf.domain.LeaderboardEntity;
 import com.mjsec.ctf.service.HistoryService;
 import com.mjsec.ctf.service.LeaderboardService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +9,6 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import java.io.IOException;
@@ -35,8 +34,8 @@ public class LeaderboardController {
         new Thread(() -> {
             try {
                 while (true) {
-                    List<Leaderboard> leaderboardEntities = leaderboardService.getLeaderboard();
-                    emitter.send(leaderboardEntities, MediaType.APPLICATION_JSON);
+                    List<LeaderboardEntity> leaderboardEntityEntities = leaderboardService.getLeaderboard();
+                    emitter.send(leaderboardEntityEntities, MediaType.APPLICATION_JSON);
                     Thread.sleep(5000); // 5초마다 업데이트
                 }
             } catch (IOException | InterruptedException e) {

--- a/Back/src/main/java/com/mjsec/ctf/domain/HistoryEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/HistoryEntity.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
-@Table(name = "history")
 public class HistoryEntity {
 
     @Id

--- a/Back/src/main/java/com/mjsec/ctf/domain/LeaderboardEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/LeaderboardEntity.java
@@ -1,4 +1,4 @@
-package com.mjsec.ctf.entity;
+package com.mjsec.ctf.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -11,8 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
-@Table(name = "leaderboard")  // 테이블 이름 명시
-public class Leaderboard {
+public class LeaderboardEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)  // id 자동 증가

--- a/Back/src/main/java/com/mjsec/ctf/filter/JwtFilter.java
+++ b/Back/src/main/java/com/mjsec/ctf/filter/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.mjsec.ctf.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mjsec.ctf.repository.BlacklistedTokenRepository;
 import com.mjsec.ctf.service.JwtService;
 import com.mjsec.ctf.type.UserRole;
@@ -9,6 +10,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -76,8 +78,20 @@ public class JwtFilter extends OncePerRequestFilter {
                     String newAccessToken = tokens.get("accessToken");
                     String newRefreshToken = tokens.get("refreshToken");
 
+                    /* 프론트에 json 형태로 토큰 전달하기 때문에 주석 처리
                     response.setHeader("Authorization", "Bearer " + newAccessToken);
-                    response.addCookie(createCookie("refreshToken", newRefreshToken));
+                    response.addCookie(createCookie("refreshToken", newRefreshToken);
+                    */
+
+                    // JSON 응답으로 새로운 토큰 반환
+                    response.setContentType("application/json");
+                    response.setCharacterEncoding("UTF-8");
+
+                    Map<String, String> tokenResponse = new HashMap<>();
+                    tokenResponse.put("accessToken", newAccessToken);
+                    tokenResponse.put("refreshToken", newRefreshToken);
+
+                    response.getWriter().write(new ObjectMapper().writeValueAsString(tokenResponse));
 
                     accessToken = newAccessToken;
                 } catch (Exception e) {

--- a/Back/src/main/java/com/mjsec/ctf/repository/LeaderboardRepository.java
+++ b/Back/src/main/java/com/mjsec/ctf/repository/LeaderboardRepository.java
@@ -1,6 +1,6 @@
 package com.mjsec.ctf.repository;
 
-import com.mjsec.ctf.entity.Leaderboard;
+import com.mjsec.ctf.domain.LeaderboardEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,11 +8,11 @@ import java.util.Optional;
 import java.util.List;
 
 @Repository
-public interface LeaderboardRepository extends JpaRepository<Leaderboard, Long> {
+public interface LeaderboardRepository extends JpaRepository<LeaderboardEntity, Long> {
 
     // 정렬 방법 변경했습니다
-    List<Leaderboard> findAllByOrderByTotalPointDescLastSolvedTimeAsc();
+    List<LeaderboardEntity> findAllByOrderByTotalPointDescLastSolvedTimeAsc();
     
     // 특정 회원의 Leaderboard 정보를 조회하는 메서드 추가
-    Optional<Leaderboard> findByUserId(String userId);
+    Optional<LeaderboardEntity> findByUserId(String userId);
 }

--- a/Back/src/main/java/com/mjsec/ctf/repository/SubmissionRepository.java
+++ b/Back/src/main/java/com/mjsec/ctf/repository/SubmissionRepository.java
@@ -1,12 +1,17 @@
 package com.mjsec.ctf.repository;
 
 import com.mjsec.ctf.domain.SubmissionEntity;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SubmissionRepository extends JpaRepository<SubmissionEntity, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM SubmissionEntity s WHERE s.loginId = :loginId AND s.challengeId = :challengeId")
     Optional<SubmissionEntity> findByLoginIdAndChallengeId(String loginId, Long challengeId);
 }

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -5,7 +5,7 @@ import com.mjsec.ctf.domain.HistoryEntity;
 import com.mjsec.ctf.domain.SubmissionEntity;
 import com.mjsec.ctf.domain.UserEntity;
 import com.mjsec.ctf.dto.ChallengeDto;
-import com.mjsec.ctf.entity.Leaderboard;
+import com.mjsec.ctf.domain.LeaderboardEntity;
 import com.mjsec.ctf.exception.RestApiException;
 import com.mjsec.ctf.repository.ChallengeRepository;
 import com.mjsec.ctf.repository.HistoryRepository;
@@ -275,20 +275,20 @@ public class ChallengeService {
     private void updateLeaderboard(UserEntity user, LocalDateTime solvedTime) {
         // 이미 존재하는 Leaderboard 레코드를 조회
         var optionalLeaderboard = leaderboardRepository.findByUserId(user.getLoginId());
-        com.mjsec.ctf.entity.Leaderboard leaderboard;
+        LeaderboardEntity leaderboardEntity;
         if (optionalLeaderboard.isPresent()) {
-            leaderboard = optionalLeaderboard.get();
+            leaderboardEntity = optionalLeaderboard.get();
         } else {
-            leaderboard = new com.mjsec.ctf.entity.Leaderboard();
-            leaderboard.setUserId(user.getLoginId());
+            leaderboardEntity = new LeaderboardEntity();
+            leaderboardEntity.setUserId(user.getLoginId());
         }
         
         // 사용자의 TotalPoint 와 LastSolvedTIme, Univ
-        leaderboard.setTotalPoint(user.getTotalPoint());
-        leaderboard.setLastSolvedTime(solvedTime);
-        leaderboard.setUniv(user.getUniv());
+        leaderboardEntity.setTotalPoint(user.getTotalPoint());
+        leaderboardEntity.setLastSolvedTime(solvedTime);
+        leaderboardEntity.setUniv(user.getUniv());
         
-        leaderboardRepository.save(leaderboard);
+        leaderboardRepository.save(leaderboardEntity);
     }
 
     // 문제 점수 계산기 ver.1
@@ -381,12 +381,12 @@ public class ChallengeService {
                 user.setTotalPoint(0);
                 userRepository.save(user);
 
-                Leaderboard leaderboard = leaderboardRepository.findByUserId(user.getLoginId())
+                LeaderboardEntity leaderboardEntity = leaderboardRepository.findByUserId(user.getLoginId())
                         .orElseThrow(() -> new RestApiException(ErrorCode.LEADERBOARD_NOT_FOUND));
 
-                leaderboard.setTotalPoint(0);
-                leaderboard.setLastSolvedTime(null);
-                leaderboardRepository.save(leaderboard);
+                leaderboardEntity.setTotalPoint(0);
+                leaderboardEntity.setLastSolvedTime(null);
+                leaderboardRepository.save(leaderboardEntity);
             }
 
             return;

--- a/Back/src/main/java/com/mjsec/ctf/service/JwtService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/JwtService.java
@@ -115,8 +115,8 @@ public class JwtService {
         String loginId = getLoginId(refreshToken);
         List<String> roles = getRoles(refreshToken);
 
-        String newAccessToken = createJwt("accessToken", loginId, roles, 3600000L);
-        String newRefreshToken = createJwt("refreshToken", loginId, roles, 43200000L);
+        String newAccessToken = createJwt("accessToken", loginId, roles, 600_000L); // 10분
+        String newRefreshToken = createJwt("refreshToken", loginId, roles, 86_400_000L); // 24시간
 
         refreshRepository.deleteByRefresh(refreshToken);
         addRefreshEntity(loginId, newRefreshToken, 43200000L);

--- a/Back/src/main/java/com/mjsec/ctf/service/LeaderboardService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/LeaderboardService.java
@@ -1,6 +1,6 @@
 package com.mjsec.ctf.service;
 
-import com.mjsec.ctf.entity.Leaderboard;
+import com.mjsec.ctf.domain.LeaderboardEntity;
 import com.mjsec.ctf.repository.LeaderboardRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -18,7 +18,7 @@ public class LeaderboardService {
     }
 
     // 모든 유저의 userid, total_poing, univ 데이터를 가져오는 메서드
-    public List<Leaderboard> getLeaderboard() {
+    public List<LeaderboardEntity> getLeaderboard() {
         return leaderboardRepository.findAllByOrderByTotalPointDescLastSolvedTimeAsc(); // 모든 데이터를 total_point 기준 내림차순으로 가져오기
     }
     // 여기서 한 부분이 달라졌는데 본래 updatedAt 으로 정렬하던것을 LastSolvedTime 으로 정렬하게 바꿨습니다

--- a/Back/src/main/resources/templates/leaderboard.html
+++ b/Back/src/main/resources/templates/leaderboard.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 <h1>개인별 점수</h1>
-<table id="leaderboard">
+<table id="leaderboardEntity">
   <thead>
   <tr>
     <th>이름</th>
@@ -25,8 +25,8 @@
     <th>점수</th>
   </tr>
   </thead>
-  <tbody id="leaderboard-body">
-  <!-- leaderboard data will be dynamically inserted here -->
+  <tbody id="leaderboardEntity-body">
+  <!-- leaderboardEntity data will be dynamically inserted here -->
   </tbody>
 </table>
 
@@ -45,11 +45,11 @@
 
 <script>
   // SSE 연결 설정
-  const eventSource = new EventSource('/leaderboard/stream');
+  const eventSource = new EventSource('/leaderboardEntity/stream');
 
   eventSource.onmessage = function(event) {
-    const leaderboard = JSON.parse(event.data);
-    const leaderboardBody = document.getElementById('leaderboard-body');
+    const leaderboardEntity = JSON.parse(event.data);
+    const leaderboardBody = document.getElementById('leaderboardEntity-body');
     const schoolScoresBody = document.getElementById('school-scores-body');
 
     leaderboardBody.innerHTML = '';  // 기존 내용 지우기
@@ -60,7 +60,7 @@
     // 학교별 점수 합산 계산
     const schoolScores = {};
 
-    leaderboard.forEach(item => {
+    leaderboardEntity.forEach(item => {
       // 리더보드에 항목 추가
       const row = document.createElement('tr');
       row.innerHTML = `


### PR DESCRIPTION
# 변경사항
- jwt 토큰을 재발급할 때 프론트로 json 데이터를 넘겨주게 됩니다.(access 토큰, refresh 토큰)
- 동시성 문제를 제어하기 위해 SubmissionEntityRepository에 Lock 기능을 추가하였습니다.