### PR TITLE
fix(submit): add Redisson for concurrency control

### DIFF
--- a/Back/build.gradle
+++ b/Back/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	// Google Cloud Platform Storage(GCP Storage)
 	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.5.RELEASE'
 	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.5.RELEASE'
+	// Redisson
+	implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/Back/src/main/java/com/mjsec/ctf/config/RedisConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package com.mjsec.ctf.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,5 +38,15 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
+    }
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + host + ":" + port)
+                .setConnectionPoolSize(10) // 최대 연결 수를 설정하며, 동시에 얼마나 많은 클라이언트가 Redis와 연결을 맺을 수 있을지를 결정
+                .setConnectionMinimumIdleSize(5); // 최소 유휴 연결 수를 설정하여, 연결 풀이 항상 일정 수의 연결을 유지하게 하고, 즉시 사용할 수 있는 연결을 보장
+        return Redisson.create(config);
     }
 }


### PR DESCRIPTION
## 변경 사항

redis에서 지원해주는 락 기능을 사용하여 동시성을 제어합니다.
- build.gradle에 의존성 추가
<img width="597" alt="스크린샷 2025-03-26 오후 6 46 34" src="https://github.com/user-attachments/assets/d928ffe9-8b1d-4ef0-8584-5bef781d4011" />

- RedisConfig에 최대 연결 수 와 최소 유휴 연결 수 설정
<img width="1013" alt="스크린샷 2025-03-26 오후 6 46 56" src="https://github.com/user-attachments/assets/2b26cf54-cc92-4b26-88b1-2e6e1bd8da0e" />

- submit 함수에서 정답 문자열은 맞지만 제출이 되지 않은 상태라면, 락을 걸고 내부 로직이 끝날 때까지 다른 요청이 대기하도록 합니다.(큐 방식) 퍼스트 블러드가 여러번 호출되지 않도록 합니다.
<img width="523" alt="스크린샷 2025-03-26 오후 6 48 54" src="https://github.com/user-attachments/assets/88ffab89-09d9-4751-82ab-3812138a0c4c" />
