### PR TITLE
fix(submit): add pessimistic lock in history repository

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
+++ b/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
@@ -1,7 +1,10 @@
 package com.mjsec.ctf.repository;
 
 import com.mjsec.ctf.domain.HistoryEntity;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -37,4 +40,9 @@ public interface HistoryRepository extends JpaRepository<HistoryEntity, Long> {
     @Modifying
     @Query("DELETE FROM HistoryEntity h WHERE h.userId = :userId")
     void deleteByUserId(@Param("userId") String userId);
+
+    // 비관적 락을 적용하여 조회
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT h FROM HistoryEntity h WHERE h.userId = :userId AND h.challengeId = :challengeId")
+    Optional<HistoryEntity> findWithLockByUserIdAndChallengeId(@Param("userId") String userId, @Param("challengeId") Long challengeId);
 }

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -231,7 +231,7 @@ public class ChallengeService {
             ChallengeEntity challenge = challengeRepository.findById(challengeId)
                     .orElseThrow(() -> new RestApiException(ErrorCode.CHALLENGE_NOT_FOUND));
 
-            if (historyRepository.existsByUserIdAndChallengeId(user.getLoginId(), challengeId)) {
+            if (historyRepository.findWithLockByUserIdAndChallengeId(user.getLoginId(), challengeId).isPresent()) {
                 return "Submitted";
             }
 
@@ -244,7 +244,7 @@ public class ChallengeService {
                             .build());
 
             long secondsSinceLastAttempt = ChronoUnit.SECONDS.between(submission.getLastAttemptTime(), LocalDateTime.now());
-            if (submission.getAttemptCount() >= 3 && secondsSinceLastAttempt < 30) {
+            if (submission.getAttemptCount() > 2 && secondsSinceLastAttempt < 30) {
                 return "Wait";
             }
 


### PR DESCRIPTION
## 변경사항

- 동시성 문제 해결을 위해 history 레포지토리 내부에서 비관적 락을 사용하여 히스토리를 조회합니다.
- 이전에는 제출 시도가 3회 이상이면 30초 대기를 걸었지만, 2회로 줄였습니다.(동시성과는 별도의 이슈)