### PR TITLE
Feat: 강한 의존성, 약한 의존성 처리하기

### DIFF
--- a/Back/build.gradle
+++ b/Back/build.gradle
@@ -42,7 +42,6 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.104.Final:osx-aarch_64'
 	annotationProcessor 'org.projectlombok:lombok'
-
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/Back/src/main/java/com/mjsec/ctf/controller/LeaderboardController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/LeaderboardController.java
@@ -87,7 +87,7 @@ public class LeaderboardController {
 
         scheduleSseTask(emitter, () -> {
             try {
-                List<HistoryDto> historyDtos = historyService.getHistoryDtos();
+                List<HistoryDto> historyDtos = historyService.getActiveUserHistoryDtos();
                 emitter.send(
                         SseEmitter.event()
                                 .name("update")

--- a/Back/src/main/java/com/mjsec/ctf/controller/UserController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/UserController.java
@@ -39,40 +39,26 @@ public class UserController {
     @Operation(summary = "회원가입", description = "유저 등록")
     @PostMapping("/sign-up")
     public ResponseEntity<SuccessResponse<Void>> signUp(@RequestBody @Valid UserDTO.SignUp request) {
-        if (!userService.isAllowedDomain(request.getEmail())) {
-            throw new RestApiException(ErrorCode.UNAUTHORIZED_EMAIL);
-        }
 
-        userService.signUp(request); // 🚀 회원가입 서비스 호출
+        userService.signUp(request); // 회원가입 서비스 호출
+
         return ResponseEntity.status(201).body(SuccessResponse.of(ResponseMessage.SIGNUP_SUCCESS));
     }
 
     @Operation(summary = "ID 확인", description = "해당 ID 사용 여부 확인 API")
     @GetMapping("/check-id")
     public ResponseEntity<Map<String, String>> checkLoginId(@RequestParam String loginId) {
-        userService.validateLoginId(loginId);
-        boolean exists = userService.isLoginIdExists(loginId);
-        if (exists) {
-            throw new RestApiException(ErrorCode.DUPLICATE_ID);
-        }
+
+        userService.checkLoginId(loginId);
+
         return ResponseEntity.ok(Map.of("message", "사용 가능한 아이디입니다."));
     }
 
     @Operation(summary = "이메일 확인", description = "해당 이메일 사용 여부 확인 API")
     @GetMapping("/check-email")
     public ResponseEntity<Map<String, String>> checkEmail(@RequestParam String email) {
-        if (!userService.isValidEmail(email)) {
-            throw new RestApiException(ErrorCode.INVALID_EMAIL_FORMAT);
-        }
+        userService.checkEmail(email);
 
-        if(!userService.isAllowedDomain(email)){
-            throw new RestApiException(ErrorCode.UNAUTHORIZED_EMAIL);
-        }
-
-        boolean exists = userService.isEmailExists(email);
-        if (exists) {
-            throw new RestApiException(ErrorCode.DUPLICATE_EMAIL);
-        }
         return ResponseEntity.ok(Map.of("message","사용 가능한 이메일입니다."));
     }
 
@@ -96,16 +82,11 @@ public class UserController {
     @Operation(summary = "유저 이메일 인증 코드 보내기", description = "해당하는 학교 이메일만 인증 코드 보내기")
     @PostMapping("/send-code")
     public ResponseEntity<String> sendAuthCode(@RequestParam String email) {
-        if (!userService.isValidEmail(email)) {
-            throw new RestApiException(ErrorCode.INVALID_EMAIL_FORMAT);
-        }
-
-        if (!userService.isAllowedDomain(email)) {
-            throw new RestApiException(ErrorCode.UNAUTHORIZED_EMAIL);
-        }
+        userService.checkEmail(email);
 
         String code = authCodeService.generateAndStoreCode(email);
         emailService.sendVerificationEmail(email, code);
+
         return ResponseEntity.ok("인증 코드가 전송되었습니다.");
     }
 

--- a/Back/src/main/java/com/mjsec/ctf/domain/HistoryEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/HistoryEntity.java
@@ -1,10 +1,7 @@
 package com.mjsec.ctf.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import java.time.LocalDateTime;
 
@@ -26,6 +23,19 @@ public class HistoryEntity {
 
     private LocalDateTime solvedTime;
 
-    @Column(name = "univ")
-    private String univ; //univ 추가
+    @Column(name = "univ", nullable=false)
+    private String univ;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean userDeleted = false;
+
+    //사용자 삭제 처리
+    public void anonymizeUser() {
+        //loginId null처리
+        this.loginId = null;
+        //삭제 처리
+        this.userDeleted = true;
+    }
+
 }

--- a/Back/src/main/java/com/mjsec/ctf/domain/LeaderboardEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/LeaderboardEntity.java
@@ -1,5 +1,6 @@
 package com.mjsec.ctf.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -18,8 +19,13 @@ public class LeaderboardEntity {
     @Column(name = "id")  // DB 컬럼명 매칭
     private Long id;
 
-    @Column(name = "loginId")  // userId// 컬럼 매핑 <-loginId 로 수정
+    @Column(name = "loginId") // 컬럼 매핑 <-loginId 로 수정
     private String loginId;
+
+    @JsonIgnore
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "loginId", referencedColumnName = "loginId", insertable=false, updatable=false)
+    private UserEntity user;
 
     @Column(name = "total_point")  // total_point 컬럼 매핑
     private int totalPoint;

--- a/Back/src/main/java/com/mjsec/ctf/domain/RefreshEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/RefreshEntity.java
@@ -1,9 +1,6 @@
 package com.mjsec.ctf.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,8 +12,15 @@ public class RefreshEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String loginId;
+
     private String refresh;
+
     private String expiration;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "loginId", referencedColumnName = "loginId", insertable = false, updatable = false)
+    private UserEntity user;
 
 }

--- a/Back/src/main/java/com/mjsec/ctf/domain/SubmissionEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/SubmissionEntity.java
@@ -1,10 +1,7 @@
 package com.mjsec.ctf.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,4 +32,8 @@ public class SubmissionEntity {
 
     @Column
     private LocalDateTime lastAttemptTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "loginId", referencedColumnName = "loginId", insertable=false, updatable=false)
+    private UserEntity user;
 }

--- a/Back/src/main/java/com/mjsec/ctf/domain/UserEntity.java
+++ b/Back/src/main/java/com/mjsec/ctf/domain/UserEntity.java
@@ -1,5 +1,6 @@
 package com.mjsec.ctf.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.mjsec.ctf.type.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
@@ -45,4 +46,14 @@ public class UserEntity extends BaseEntity {
 
     @Column(nullable = false)
     private int totalPoint;
+
+    @JsonIgnore
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private LeaderboardEntity leaderboard;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<SubmissionEntity> submissions;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<RefreshEntity> refreshTokens;
 }

--- a/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
+++ b/Back/src/main/java/com/mjsec/ctf/repository/HistoryRepository.java
@@ -21,10 +21,9 @@ public interface HistoryRepository extends JpaRepository<HistoryEntity, Long> {
     // userId → loginId로 변경
     List<HistoryEntity> findByLoginId(String loginId);
 
-    @Query("SELECT COUNT(DISTINCT h.loginId) FROM HistoryEntity h WHERE h.challengeId = :challengeId")
+    @Query("SELECT COUNT(DISTINCT h.loginId) FROM HistoryEntity h WHERE h.challengeId = :challengeId AND h.userDeleted = false AND h.loginId IS NOT NULL")
     long countDistinctByChallengeId(Long challengeId);
 
-    // 메서드명과 파라미터명 모두 변경
     @Query("SELECT COUNT(h) > 0 FROM HistoryEntity h WHERE h.loginId = :loginId AND h.challengeId = :challengeId")
     boolean existsByLoginIdAndChallengeId(@Param("loginId") String loginId, @Param("challengeId") Long challengeId);
 
@@ -48,4 +47,10 @@ public interface HistoryRepository extends JpaRepository<HistoryEntity, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT h FROM HistoryEntity h WHERE h.loginId = :loginId AND h.challengeId = :challengeId")
     Optional<HistoryEntity> findWithLockByLoginIdAndChallengeId(@Param("loginId") String loginId, @Param("challengeId") Long challengeId);
+
+    @Query("SELECT h FROM HistoryEntity h WHERE h.userDeleted = true")
+    List<HistoryEntity> findByUserDeletedTrue();
+
+    @Query("SELECT h FROM HistoryEntity h WHERE h.loginId = :loginId AND h.userDeleted = false")
+    List<HistoryEntity> findByLoginIdAndUserDeletedFalse(@Param("loginId") String loginId);
 }

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -58,7 +58,7 @@ public class ChallengeService {
     BcryptPasswordEncoder -> PasswordEncoder로 변경해서 진행했음.
     (혹시 몰라 메모해둠)
      */
-    private final BcryptPasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder passwordEncoder;
     private final RedissonClient redissonClient;
 
     @Value("${api.key}")

--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -35,6 +35,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
@@ -51,12 +52,13 @@ public class ChallengeService {
     private final HistoryRepository historyRepository;
     private final LeaderboardRepository leaderboardRepository;
     private final SubmissionRepository submissionRepository;
+
     /*
     7월 30일자 테스트할 땐
     BcryptPasswordEncoder -> PasswordEncoder로 변경해서 진행했음.
     (혹시 몰라 메모해둠)
      */
-    private final BCryptPasswordEncoder passwordEncoder;
+    private final BcryptPasswordEncoder passwordEncoder;
     private final RedissonClient redissonClient;
 
     @Value("${api.key}")
@@ -322,40 +324,7 @@ public class ChallengeService {
         leaderboardRepository.save(leaderboardEntity);
     }
 
-    // 문제 점수 계산기 ver.1
-    /*
-    public void updateChallengeScore(ChallengeEntity challenge) {
-        
-        // 현재 챌린지를 해결한 사용자 수를 계산
-        long solvedCount = historyRepository.countDistinctByChallengeId(challenge.getChallengeId());
-        
-        // 전체 참가자 수를 계산
-        long totalParticipants = userRepository.count();
-    
-        double maxDecrementFactor = 0.9;
-
-        double newPoints;
-        if (totalParticipants > 1) {
-            // 점수 감소 비율 계산
-            double decrementFactor = maxDecrementFactor * (solvedCount - 1) / (totalParticipants - 1);
-            decrementFactor = Math.min(decrementFactor, maxDecrementFactor);
-    
-            // 초기 점수에서 점수를 감소시킴
-            newPoints = challenge.getInitialPoints() * (1 - decrementFactor);
-           // 최소 점수 이하로 떨어지지 않도록 함
-            newPoints = Math.max(newPoints, challenge.getMinPoints());
-        } else {
-            newPoints = challenge.getInitialPoints();  // 참가자가 1명 이하인 경우 초기 점수 유지
-        }
-    
-        newPoints = Math.floor(newPoints);
-        challenge.setPoints((int)newPoints);
-    
-        challengeRepository.save(challenge);
-    }
-     */
-
-    // 문제 점수 계산기 ver.2
+    // 문제 점수 계산기 (updateChallengeScore 메서드 수정 - 삭제된 사용자 제외)
     public void updateChallengeScore(ChallengeEntity challenge) {
 
         long solvedCount = historyRepository.countDistinctByChallengeId(challenge.getChallengeId());
@@ -423,7 +392,7 @@ public class ChallengeService {
         }
 
         for (String loginId : loginIds) {
-            List<HistoryEntity> userHistoryList = historyRepository.findByLoginId(loginId);
+            List<HistoryEntity> userHistoryList = historyRepository.findByLoginIdAndUserDeletedFalse(loginId);
 
             List<Long> challengeIds = userHistoryList.stream()
                     .map(HistoryEntity::getChallengeId)

--- a/Back/src/main/java/com/mjsec/ctf/service/HistoryService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/HistoryService.java
@@ -24,6 +24,11 @@ public class HistoryService {
      * HistoryEntity들을 조회하여, 각 기록에 해당하는 ChallengeEntity의 최신 동적 점수(ChallengeEntity.points)를 HistoryDto에 반영합니다.
      * @return List of HistoryDto sorted by solvedTime ascending.
      */
+
+    /*
+    getHistoryDtos -> 전체 멤버 (삭제 유저 포함) 조회로 수정.
+    실질적인 삭제 안 된 유저는 getActiveUserHistoryDtos 로 바꿈.
+     */
     public List<HistoryDto> getHistoryDtos() {
         List<HistoryEntity> histories = historyRepository.findAllByOrderBySolvedTimeAsc();
         return histories.stream().map(history -> {
@@ -42,6 +47,29 @@ public class HistoryService {
                     history.getSolvedTime(),
                     dynamicScore,
                     univ //univ 포함
+            );
+        }).collect(Collectors.toList());
+    }
+
+    //삭제되지 않은 유저들만 조회
+    public List<HistoryDto> getActiveUserHistoryDtos() {
+        List<HistoryEntity> histories = historyRepository.findAllByOrderBySolvedTimeAsc()
+                .stream()
+                .filter(h -> !h.isUserDeleted() && h.getLoginId() != null)
+                .collect(Collectors.toList());
+
+        return histories.stream().map(history -> {
+            ChallengeEntity challenge = challengeRepository.findById(history.getChallengeId())
+                    .orElse(null);
+            int dynamicScore = (challenge != null) ? challenge.getPoints() : 0;
+
+            return new HistoryDto(
+                    history.getLoginId(),
+                    String.valueOf(history.getChallengeId()),
+                    challenge != null ? challenge.getTitle() : "Unknown Challenge",
+                    history.getSolvedTime(),
+                    dynamicScore,
+                    history.getUniv()
             );
         }).collect(Collectors.toList());
     }

--- a/Back/src/main/resources/application-local.yml
+++ b/Back/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 spring:
   redis:
-    host: redis
-    port: 6379
-    timeout: 6000
+      host: redis
+      port: 6379
+      timeout: 6000
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
### 강한 의존성 + 약한 의존성 설정

User 삭제했을 때를 기준으로 자동으로 함께 삭제되는 경우를 ‘강한 의존성’ 으로 잡고,

반대로 User 삭제해도 loginId를 NULL 처리하는 방식으로 일단 데이터를 남기는 걸 ‘약한 의존성’으로 잡음.

강한 의존성

- LeaderboardEntity
- SubmissionEntity
- RefreshEntity

각각 Entity들을 UserEntity와 연관 관계 설정함.

**UserEntity**

```jsx
package com.mjsec.ctf.domain;

import com.fasterxml.jackson.annotation.JsonIgnore;
import com.mjsec.ctf.type.UserRole;
import jakarta.persistence.*;
import lombok.*;
import org.hibernate.annotations.Fetch;
import org.hibernate.annotations.FetchMode;

import java.time.LocalDateTime;
import java.util.List;

@Entity
@Getter
@Setter
@NoArgsConstructor
@AllArgsConstructor
@Builder
public class UserEntity extends BaseEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long userId;

    @Column(nullable = false, unique = true)
    private String loginId;

    @Column(nullable = false)
    private String password;

    @Column(nullable = false, unique = true)
    private String email;

    @Column(nullable = false)
    private String univ;

    /* 처음엔 UserRole로 설정했으나 ERD 설계로 String 타입으로 변경
    @ElementCollection(fetch = FetchType.EAGER)
    @Enumerated(EnumType.STRING)
    @Fetch(FetchMode.JOIN)
    private List<UserRole> roles;
     */

    @Column(nullable = false)
    private String roles;

    @Column(nullable = false)
    private int totalPoint;

    @JsonIgnore
    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
    private LeaderboardEntity leaderboard;

    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
    private List<SubmissionEntity> submissions;

    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
    private List<RefreshEntity> refreshTokens;
}
```

HistoryEntity의 경우 문제 해결 기록이 남는거라 일단 삭제되어도 기록은 남도록 ‘약한 의존성’으로 설정함.

```jsx
package com.mjsec.ctf.domain;

import jakarta.persistence.*;
import lombok.*;
import lombok.experimental.SuperBuilder;
import java.time.LocalDateTime;

@Entity
@Getter
@Setter
@NoArgsConstructor
@AllArgsConstructor
@SuperBuilder
public class HistoryEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    private String loginId;

    private Long challengeId;

    private LocalDateTime solvedTime;

    @Column(name = "univ", nullable=false)
    private String univ;

    @Column(nullable = false)
    @Builder.Default
    private boolean userDeleted = false;

    //사용자 삭제 처리
    public void anonymizeUser() {
        //loginId null처리
        this.loginId = null;
        //삭제 처리
        this.userDeleted = true;
    }

}
```

**동작 방식**

- 어드민 기준 : delete/{userId} 를 통해 user를 삭제할 경우
    - 동시에 leaderboard , submission , refresh Entity들 모두 유저 데이터가 삭제됨.
    - 약한 의존성인 history 의 경우, loginId가 `NULL` 로 바뀌며, userDeleted 변수가 `true` 로 바뀜.
    
    → /leaderboard/graph 에서는 userDeleted가 false인 즉 삭제되지 않는 유저만 뜨도록 변경함.
    

**여담**

하면서 느낀 건 *“일단 이게 맞긴 한건가..?”* 였습니다요…

많은 피드백 부탁함. + 방향성을 제시해줘도 좋아요 : )

그리고 history 의 경우 loginId를 `NULL`로 바꾼다고 했는데, 대신 `deletedUser001` 뭐 이런 식으로 바꾸는 것도 괜찮을 거 같은데 어떻게 생각하시나요?

### 앞으로 할 거

현재 delete 방식은 hard delete 방식인데, soft delete 방식을 쓰는 건 어떨까? 생각함.

(BaseEntity 에 deletedAt 도 있으므로)

→ 만약 수정한다면 관련 API도 같이 수정해야 할 것임.

---

### 수정된 내용

- **UserEntity.java**
    - JPA 관계 설정 추가: `@OneToOne`, `@OneToMany`로 강한 의존성 구현
    - Cascade Delete 설정: `cascade = CascadeType.ALL, orphanRemoval = true`
- **LeaderboardEntity.java**
    - UserEntity와 양방향 관계 설정
    - `insertable=false, updatable=false` 추가로 컬럼 중복 매핑 오류 해결
- **SubmissionEntity.java**
    - UserEntity와 다대일 관계 설정
    - `insertable=false, updatable=false` 추가
- **RefreshEntity.java**
    - UserEntity와 다대일 관계 설정
    - `insertable=false, updatable=false` 추가
- **HistoryEntity.java**
    - 사용자 삭제 추적을 위한 `userDeleted` 필드 추가
    - 사용자 삭제시 NULL 처리를 위한 `anonymizeUser()` 메서드 구현
- **HistoryRepository.java**
    - 필드명 통일에 따른 쿼리 메서드 수정
    - 삭제된 사용자 조회 메서드 추가: `findByUserDeletedTrue()`, `findByLoginIdAndUserDeletedFalse()`
- **LeaderboardRepository.java**
    - 메서드명 수정: `findByUserId()` → `findByLoginId()`
- **UserService.java**
    - `deleteMember()` 메서드 개선: 강한/약한 의존성 분리 처리
        - **강한 의존성**: JPA Cascade로 자동 삭제 (Leaderboard, Submission, Refresh)
        - **약한 의존성**: 수동 익명화 처리 (History)
    - validate (검증용) 메서드들 밑으로 분리 + `private` 설정
- **HistoryService.java**
    - 삭제된 사용자 처리 로직 추가 →`getActiveUserHistoryDtos()`
    - **LeaderboardController의 `/leaderboard/graph` 에서 사용되는 함수를 `getActiveUserHistoryDtos()` 로 교체함**
- **ChallengeService.java**
    - 필드명 통일에 따른 메서드 수정
    - **점수 계산 시 활성 사용자만 고려하도록 개선 (Repository로 삭제 안 된 유저만 가져오도록 수정함)**
    

---

### 테스트

테스트용 유저 새로 만듬 (어드민 계정으로)

```jsx
[
    {
        "userId": 1,
        "email": "admin@example.com",
        "loginId": "admin",
        "roles": "ROLE_ADMIN",
        "totalPoint": 0,
        "univ": "Admin Univ",
        "createdAt": "2025-07-30T16:07:55.446102",
        "updatedAt": "2025-07-30T16:07:55.446102"
    },
    {
        "userId": 2,
        "email": "tember8003@mju.ac.kr",
        "loginId": "mjsec1234",
        "roles": "ROLE_USER",
        "totalPoint": 100,
        "univ": "명지대학교",
        "createdAt": "2025-07-30T16:37:49.215614",
        "updatedAt": "2025-07-31T10:47:46.211628"
    },
    {
        "userId": 3,
        "email": "testuser001@mju.ac.kr",
        "loginId": "testuser001",
        "roles": "ROLE_USER",
        "totalPoint": 100,
        "univ": "명지대학교",
        "createdAt": "2025-08-09T16:24:14.25347",
        "updatedAt": "2025-08-09T16:41:03.73517"
    }
]
```

문제를 풀었다고 가정하고 해당 테스트 유저로 로그인한 후 FLAG를 제출함.

스트림 확인

<img width="664" height="252" alt="image" src="https://github.com/user-attachments/assets/8428eaef-c4ac-4989-a9b0-eadb49f520cf" />

```jsx
[
    {
        "id": 1,
        "loginId": "mjsec1234",
        "totalPoint": 100,
        "lastSolvedTime": "2025-07-31T10:47:46.092915",
        "univ": "명지대학교"
    },
    {
        "id": 2,
        "loginId": "testuser001",
        "totalPoint": 100,
        "lastSolvedTime": "2025-08-09T16:41:03.677066",
        "univ": "명지대학교"
    }
]
```
</br>
테스트할 것 (사실 테스트용으로 2~5번까지도 만들어놨는데 생성만 해두고 냅뒀음.)

```jsx
mysql> SELECT login_id, email, univ FROM user_entity;
+-------------+-----------------------+------------+
| login_id    | email                 | univ       |
+-------------+-----------------------+------------+
| admin       | admin@example.com     | Admin Univ |
| mjsec1234   | tember8003@mju.ac.kr  | ?????      |
| testuser001 | testuser001@mju.ac.kr | ?????      |
| testuser002 | testuser002@mju.ac.kr | ?????      |
| testuser003 | testuser003@mju.ac.kr | ?????      |
| testuser004 | testuser004@mju.ac.kr | ?????      |
| testuser005 | testuser005@mju.ac.kr | ?????      |
+-------------+-----------------------+------------+
7 rows in set (0.00 sec)

mysql> SELECT login_id, total_point FROM leaderboard_entity;
+-------------+-------------+
| login_id    | total_point |
+-------------+-------------+
| mjsec1234   |         100 |
| testuser001 |         100 |
+-------------+-------------+
2 rows in set (0.00 sec)

mysql> SELECT login_id, challenge_id FROM submission_entity;
Empty set (0.00 sec)

mysql> SELECT login_id FROM refresh_entity;
+-------------+
| login_id    |
+-------------+
| admin       |
| admin       |
| admin       |
| admin       |
| mjsec1234   |
| mjsec1234   |
| mjsec1234   |
| testuser001 |
+-------------+
8 rows in set (0.00 sec)

mysql> SELECT login_id, challenge_id, univ FROM history_entity;
+-------------+--------------+-------+
| login_id    | challenge_id | univ  |
+-------------+--------------+-------+
| mjsec1234   |            1 | ????? |
| testuser001 |            1 | ????? |
+-------------+--------------+-------+
2 rows in set (0.00 sec)
```

이후 테스트 유저를 삭제할 경우 , refresh_entity와 history_entity, leaderboard_entity에서 해당 유저가 없어져야 함.
</br>

<img width="482" height="359" alt="image" src="https://github.com/user-attachments/assets/1ca7ad72-54bf-4e3e-8dd6-7c27ffef1c00" />


</br>

stream 기준 삭제 전 후로 유저가 없어짐


<img width="646" height="647" alt="image" src="https://github.com/user-attachments/assets/ae803693-550f-4226-9f07-449ff41325a8" />

MYSQL에서도 해당 테스트 유저가 없어짐

```jsx
mysql> SELECT COUNT(*) FROM user_entity WHERE login_id = 'testuser001';
+----------+
| COUNT(*) |
+----------+
|        0 |
+----------+
1 row in set (0.00 sec)

mysql> SELECT COUNT(*) FROM leaderboard_entity WHERE login_id = 'testuser001';
+----------+
| COUNT(*) |
+----------+
|        0 |
+----------+
1 row in set (0.00 sec)

mysql> SELECT COUNT(*) FROM submission_entity WHERE login_id = 'testuser001';
+----------+
| COUNT(*) |
+----------+
|        0 |
+----------+
1 row in set (0.00 sec)

mysql> SELECT COUNT(*) FROM refresh_entity WHERE login_id = 'testuser001';
+----------+
| COUNT(*) |
+----------+
|        0 |
+----------+
1 row in set (0.00 sec)
```

(사실 테스트용으로 2~5번까지도 만들어놨는데 생성만 해두고 냅뒀음.)
</br>

```jsx
mysql> SELECT login_id, email, univ FROM user_entity;
+-------------+-----------------------+------------+
| login_id    | email                 | univ       |
+-------------+-----------------------+------------+
| admin       | admin@example.com     | Admin Univ |
| mjsec1234   | tember8003@mju.ac.kr  | ?????      |
| testuser002 | testuser002@mju.ac.kr | ?????      |
| testuser003 | testuser003@mju.ac.kr | ?????      |
| testuser004 | testuser004@mju.ac.kr | ?????      |
| testuser005 | testuser005@mju.ac.kr | ?????      |
+-------------+-----------------------+------------+
6 rows in set (0.00 sec)

mysql> SELECT login_id, total_point FROM leaderboard_entity;
+-----------+-------------+
| login_id  | total_point |
+-----------+-------------+
| mjsec1234 |         100 |
+-----------+-------------+
1 row in set (0.00 sec)

mysql> SELECT login_id, challenge_id FROM submission_entity;
Empty set (0.00 sec)

mysql> SELECT login_id FROM refresh_entity;
+-----------+
| login_id  |
+-----------+
| admin     |
| admin     |
| admin     |
| admin     |
| admin     |
| mjsec1234 |
| mjsec1234 |
| mjsec1234 |
+-----------+
8 rows in set (0.00 sec)

mysql> SELECT login_id, challenge_id, univ FROM history_entity;
+-----------+--------------+-------+
| login_id  | challenge_id | univ  |
+-----------+--------------+-------+
| mjsec1234 |            1 | ????? |
| NULL      |            1 | ????? |
+-----------+--------------+-------+
2 rows in set (0.00 sec)
```

아무튼 leaderboard, submission , refresh 에서는 사라지고, 약한 의존성인 history_entity 에서는 NULL 로 표기되는 것을 확인할 수 있음.

```jsx
mysql> select * from history_entity;
+----+--------------+-----------+----------------------------+-------+----------------------------+
| id | challenge_id | login_id  | solved_time                | univ  | user_deleted               |
+----+--------------+-----------+----------------------------+-------+----------------------------+
|  3 |            1 | mjsec1234 | 2025-07-31 10:47:46.092915 | ????? | 0x00                       |
|  4 |            1 | NULL      | 2025-08-09 16:41:03.677066 | ????? | 0x01                       |
+----+--------------+-----------+----------------------------+-------+----------------------------+
2 rows in set (0.00 sec)
```

history_entity 에서, user_deleted 변수를 통해 true(0x01)인 경우엔 삭제된 경우.

아닌 경우는 false (0x00) 으로 설정되어 있음.

또한 이를 반영해 `/leaderboard/graph` API에서는 삭제되지 않은 유저만 나오도록 수정함.

<img width="609" height="301" alt="image" src="https://github.com/user-attachments/assets/e7b823de-3822-4d71-ab93-79d6428e3c78" />