### PR TITLE
Fix: CORS 설정 (환경변수 처리)

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/config/GlobalCorsConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/GlobalCorsConfig.java
@@ -6,15 +6,21 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+import org.springframework.beans.factory.annotation.Value;
+import java.util.List;
 
 @Configuration
 public class GlobalCorsConfig {
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
 
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
         // 허용할 출처를 명시합니다.
-        config.setAllowedOriginPatterns(Arrays.asList("http://localhost:*", "https://msg.mjsec.kr"));
+        List<String> origins = Arrays.asList(allowedOrigins.split(","));
+        config.setAllowedOriginPatterns(origins);
         config.setAllowCredentials(true);
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");

--- a/Back/src/main/java/com/mjsec/ctf/config/GlobalCorsConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/GlobalCorsConfig.java
@@ -1,5 +1,6 @@
 package com.mjsec.ctf.config;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,7 +20,8 @@ public class GlobalCorsConfig {
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
         // 허용할 출처를 명시합니다.
-        List<String> origins = Arrays.asList(allowedOrigins.split(","));
+        List<String> origins = new ArrayList<>(Arrays.asList(allowedOrigins.split(",")));
+        origins.add("http://localhost:3000");
         config.setAllowedOriginPatterns(origins);
         config.setAllowCredentials(true);
         config.addAllowedHeader("*");

--- a/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.beans.factory.annotation.Value;
 
     @Configuration
     @EnableWebSecurity
@@ -30,6 +31,9 @@ import org.springframework.web.cors.CorsConfigurationSource;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final BlacklistedTokenRepository blacklistedTokenRepository;
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
 
     public SecurityConfig(JwtService jwtService, RefreshRepository refreshRepository, UserRepository userRepository,PasswordEncoder passwordEncoder,BlacklistedTokenRepository blacklistedTokenRepository) {
         this.jwtService = jwtService;
@@ -52,7 +56,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
                             /*configuration.setAllowedOrigins(
                                     Arrays.asList("http://localhost:3000","https://msg.mjsec.kr")); // 배포시에는 변경될 주소 (테스트 비활성화)
                              */
-                        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000", "https://msg.mjsec.kr"));
+                        List<String> origins = Arrays.asList(allowedOrigins.split(","));
+                        configuration.setAllowedOriginPatterns(origins);
                         //configuration.setAllowedMethods(Collections.singletonList("*")); //테스트로 잠시 비활성화
                         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                         configuration.setAllowCredentials(true);

--- a/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
@@ -8,7 +8,10 @@ import com.mjsec.ctf.repository.UserRepository;
 import com.mjsec.ctf.filter.JwtFilter;
 import com.mjsec.ctf.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -56,7 +59,8 @@ import org.springframework.beans.factory.annotation.Value;
                             /*configuration.setAllowedOrigins(
                                     Arrays.asList("http://localhost:3000","https://msg.mjsec.kr")); // 배포시에는 변경될 주소 (테스트 비활성화)
                              */
-                        List<String> origins = Arrays.asList(allowedOrigins.split(","));
+                        List<String> origins = new ArrayList<>(Arrays.asList(allowedOrigins.split(",")));
+                        origins.add("http://localhost:3000");
                         configuration.setAllowedOriginPatterns(origins);
                         //configuration.setAllowedMethods(Collections.singletonList("*")); //테스트로 잠시 비활성화
                         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));

--- a/Back/src/main/resources/application-local.yml
+++ b/Back/src/main/resources/application-local.yml
@@ -45,6 +45,9 @@ spring:
         jdbc:
           time_zone: Asia/Seoul
 
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
### 이게 맞는 거겠지?

추가 

application-local.yml
```java
cors:
  allowed-origins: ${CORS_ALLOWED_ORIGINS}
```

GlobalCorsConfig.java
```java
@Configuration
public class GlobalCorsConfig {

    @Value("${cors.allowed-origins}")
    private String allowedOrigins;

    @Bean
    public CorsFilter corsFilter() {
        CorsConfiguration config = new CorsConfiguration();
        // 허용할 출처를 명시합니다.
        List<String> origins = new ArrayList<>(Arrays.asList(allowedOrigins.split(",")));
        origins.add("http://localhost:3000");
        configuration.setAllowedOriginPatterns(origins);
        config.setAllowCredentials(true);
        config.addAllowedHeader("*");
        config.addAllowedMethod("*");

        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
        source.registerCorsConfiguration("/**", config);
        return new CorsFilter(source);
    }
}
``` 

SecurityConfig 중
```java
@Value("${cors.allowed-origins}")
private String allowedOrigins;

List<String> origins = new ArrayList<>(Arrays.asList(allowedOrigins.split(",")));
origins.add("http://localhost:3000");
configuration.setAllowedOriginPatterns(origins);
``` 

