### PR TITLE
Fix: CORS용 헤더 설정, LoginFilter OPTIONS 허용

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
+++ b/Back/src/main/java/com/mjsec/ctf/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.context.annotation.Bean;
@@ -43,6 +44,7 @@ import org.springframework.beans.factory.annotation.Value;
         this.blacklistedTokenRepository = blacklistedTokenRepository;
     }
 
+
         @Bean
         public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
@@ -51,21 +53,22 @@ import org.springframework.beans.factory.annotation.Value;
                         @Override
                         public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
 
+                            System.out.println("🔍 CORS Bean 생성 중...");
                             CorsConfiguration configuration = new CorsConfiguration();
 
                             /*configuration.setAllowedOrigins(
                                     Arrays.asList("http://localhost:3000","https://msg.mjsec.kr")); // 배포시에는 변경될 주소 (테스트 비활성화)
                              */
                             configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000", "https://msgctf.kr", "https://www.msgctf.kr"));
-                        //configuration.setAllowedMethods(Collections.singletonList("*")); //테스트로 잠시 비활성화
-                        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-                        configuration.setAllowCredentials(true);
-                        //configuration.setAllowedHeaders(Collections.singletonList("*")); //테스트로 잠시 비활성화
-                        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Set-Cookie", "X-Requested-With", "Accept"));
-                        configuration.setMaxAge(3600L); // 브라우저가 CORS 관련 정보를 캐시할 시간을 설정
-                        configuration.setExposedHeaders(Arrays.asList("Authorization", "access", "X-Custom-Header"));
+                            //configuration.setAllowedMethods(Collections.singletonList("*")); //테스트로 잠시 비활성화
+                            configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+                            configuration.setAllowCredentials(true);
+                            configuration.setAllowedHeaders(Collections.singletonList("*")); //CORS 설정으로 인해 잠시 부활
+                            //configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Set-Cookie", "X-Requested-With", "Accept", "Origin"));
+                            configuration.setMaxAge(3600L); // 브라우저가 CORS 관련 정보를 캐시할 시간을 설정
+                            configuration.setExposedHeaders(Arrays.asList("Authorization", "access", "X-Custom-Header"));
 
-                        return configuration;
+                            return configuration;
                     }
                 }));
         // csrf disable (RESTful API는 일반적으로 상태가 없고, 세션을 사용하지 않기 때문에 CSRF 공격에 덜 취약하기 때문)

--- a/Back/src/main/java/com/mjsec/ctf/filter/CustomLoginFilter.java
+++ b/Back/src/main/java/com/mjsec/ctf/filter/CustomLoginFilter.java
@@ -51,9 +51,18 @@ public class CustomLoginFilter extends GenericFilterBean {
     private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws IOException, ServletException {
 
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         // 로그인 요청이 아닐 경우, 다음 필터로 넘김
-        if (!request.getServletPath().equalsIgnoreCase("/api/users/sign-in") ||
-            !"POST".equalsIgnoreCase(request.getMethod())) {
+        if (!request.getServletPath().equalsIgnoreCase("/api/users/sign-in")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
             filterChain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
**CustomLoginFilter OPTIONS 명시적 허용**
```java
if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
    filterChain.doFilter(request, response);
    return;
}
``` 

&

SecurityConfig 모든 헤더 허용
```java
configuration.setAllowedHeaders(Collections.singletonList("*")); //CORS 설정으로 인해 잠시 부활
``` 