### PR TITLE
Feat: 어드민이 문제 flag 제출 로직 추가

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/ChallengeService.java
@@ -37,6 +37,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
@@ -60,7 +61,7 @@ public class ChallengeService {
     BcryptPasswordEncoder -> PasswordEncoder로 변경해서 진행했음.
     (혹시 몰라 메모해둠)
      */
-    private final BCryptPasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
     private final RedissonClient redissonClient;
 
     @Value("${api.key}")
@@ -268,6 +269,17 @@ public class ChallengeService {
 
             ChallengeEntity challenge = challengeRepository.findById(challengeId)
                     .orElseThrow(() -> new RestApiException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+            if (user.getRole() != null && user.getRole().equals("ROLE_ADMIN")) {
+                // Admin은 플래그 검증만 하고 점수/기록은 남기지 않음
+                if (passwordEncoder.matches(flag, challenge.getFlag())) {
+                    log.info("Admin {} verified challenge {} - Correct", loginId, challengeId);
+                    return "Correct";
+                } else {
+                    log.info("Admin {} verified challenge {} - Wrong", loginId, challengeId);
+                    return "Wrong";
+                }
+            }
 
             if (user.getCurrentTeamId() == null) {
                 throw new RestApiException(ErrorCode.MUST_BE_BELONG_TEAM);


### PR DESCRIPTION
## 어드민이 문제 플래그 제출할 경우

**어드민이 플래그 제출할 경우, 히스토리에 반영되지 않고 정답 , 오답 결과만 나오도록 수정함.**

**테스트**
<img width="572" height="677" alt="image" src="https://github.com/user-attachments/assets/e63b86d8-06cd-4a27-bb8d-21c0522e3f4f" />

문제 1번에 대해 어드민이 제출할 경우

<img width="571" height="414" alt="image" src="https://github.com/user-attachments/assets/db2f028b-f60e-441a-8f64-1bc13a41fd13" />

flag 값이 맞으면 성공, 아니면 실패 로만 나오도록 수정함. (기록이 남지 않음.)

<img width="965" height="392" alt="image" src="https://github.com/user-attachments/assets/12d77913-f625-4e61-8db5-aea2a461de12" />

히스토리 기준 `login_id ‘admin’`이 존재하지 않음.

코드 상으로는

```java
if (user.getRole() != null && user.getRole().equals("ROLE_ADMIN")) {
    // Admin은 플래그 검증만 하고 점수/기록은 남기지 않음
    if (passwordEncoder.matches(flag, challenge.getFlag())) {
        log.info("Admin {} verified challenge {} - Correct", loginId, challengeId);
        return "Correct";
    } else {
        log.info("Admin {} verified challenge {} - Wrong", loginId, challengeId);
        return "Wrong";
    }
}
```

문제 제출 중간에 이 코드만 추가함. (팀 검증하기 전 먼저 어드민인지 확인 후 맞다 틀리다만 나오도록 함)