### PR TITLE
Fix: 팀원 삭제 로직 수정

### DIFF
--- a/Back/src/main/java/com/mjsec/ctf/controller/AdminController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/AdminController.java
@@ -189,6 +189,7 @@ public class AdminController {
         );
     }
 
+    //팀원 추가
     @PostMapping("/team/member/{teamName}")
     public ResponseEntity<SuccessResponse<Void>> addMember(
             @PathVariable String teamName,
@@ -204,6 +205,7 @@ public class AdminController {
         );
     }
 
+    //팀원 삭제
     @DeleteMapping("/team/member/{teamName}")
     public ResponseEntity<SuccessResponse<String>> deleteMember(
             @PathVariable String teamName,

--- a/Back/src/main/java/com/mjsec/ctf/controller/TeamController.java
+++ b/Back/src/main/java/com/mjsec/ctf/controller/TeamController.java
@@ -20,6 +20,7 @@ public class TeamController {
     private final TeamService teamService;
     private final JwtService jwtService;
 
+    //팀 프로필 확인
     @GetMapping("/profile")
     public ResponseEntity<SuccessResponse<TeamProfileDto>> getTeamProfile(
             @RequestHeader("Authorization") String authHeader) {

--- a/Back/src/main/java/com/mjsec/ctf/dto/UserDto.java
+++ b/Back/src/main/java/com/mjsec/ctf/dto/UserDto.java
@@ -34,6 +34,7 @@ public class UserDto {
 
         @NotBlank(message = "학교명을 입력해주세요.")
         private String univ;
+
         //"ROLE_USER" 또는 "ROLE_ADMIN"
         private String role;
 

--- a/Back/src/main/java/com/mjsec/ctf/service/TeamService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/TeamService.java
@@ -88,7 +88,7 @@ public class TeamService {
         TeamEntity team = teamRepository.findByTeamName(teamName)
                 .orElseThrow(() -> new RestApiException(ErrorCode.TEAM_NOT_FOUND));
 
-        if(team.isMember(user.getUserId())) {
+        if(!team.isMember(user.getUserId())) {
             throw new RestApiException(ErrorCode.TEAM_MISMATCH);
         }
 

--- a/Back/src/main/java/com/mjsec/ctf/service/UserService.java
+++ b/Back/src/main/java/com/mjsec/ctf/service/UserService.java
@@ -294,7 +294,7 @@ public class UserService {
             throw new RestApiException(ErrorCode.INVALID_EMAIL_FORMAT);
         }
 
-        // role 값이 전달되면 해당 역할을 사용하고, 없으면 기본적으로 "user"로 설정합니다.
+        // role 값이 전달되면 해당 역할을 사용하고, 없으면 기본적으로 "ROLE_USER"로 설정합니다.
         String role;
         if (request.getRole() != null && !request.getRole().isBlank()) {
             // 입력값을 대문자로 변환하여 표준 형식으로 맞춥니다.


### PR DESCRIPTION
### 팀원 삭제 로직 수정

```java
if(team.isMember(user.getUserId())) {
            throw new RestApiException(ErrorCode.TEAM_MISMATCH);
        }
```
팀원 삭제 로직 중 팀원이 해당 팀에 속한다면 삭제가 되지 않는 형태였음
그래서 테스트 중 계속 팀원이 삭제되지 않고, 
```java
{
    "code": "TEAM_MISMATCH",
    "message": "해당 팀의 팀원이 아닙니다."
}
```
가 나옴.

**수정 후**

```java
if(!team.isMember(user.getUserId())) {
            throw new RestApiException(ErrorCode.TEAM_MISMATCH);
        }
```
이와 같이 false 처리로 수정함.